### PR TITLE
Don't "use DDG::Meta::Longtail;", as it was removed in commit:ef1d5d6554

### DIFF
--- a/lib/DDG/Meta.pm
+++ b/lib/DDG/Meta.pm
@@ -9,7 +9,6 @@ use DDG::Meta::RequestHandler;
 use DDG::Meta::ZeroClickInfo;
 use DDG::Meta::ZeroClickInfoSpice;
 use DDG::Meta::Fathead;
-use DDG::Meta::Longtail;
 use DDG::Meta::ShareDir;
 use DDG::Meta::Block;
 use DDG::Meta::Information;


### PR DESCRIPTION
This fixes the testsuite, which was failing in 0.076 with the following messages:

<pre>
$ dzil test
...
t/10-meta-goodie.t ...... Can't locate DDG/Meta/Longtail.pm in @INC (@INC contains: ...)
BEGIN failed--compilation aborted at .../.build/T68uFXFz4A/blib/lib/DDG/Meta.pm line 15.
Compilation failed in require at .../.build/T68uFXFz4A/blib/lib/DDG/Goodie.pm line 10.
BEGIN failed--compilation aborted at .../.build/T68uFXFz4A/blib/lib/DDG/Goodie.pm line 10.
Compilation failed in require at .../.build/T68uFXFz4A/t/lib/DDGTest/Goodie/MetaOnly.pm line 3.
BEGIN failed--compilation aborted at .../.build/T68uFXFz4A/t/lib/DDGTest/Goodie/MetaOnly.pm line 3.
Compilation failed in require at t/10-meta-goodie.t line 12.
BEGIN failed--compilation aborted at t/10-meta-goodie.t line 12.
t/10-meta-goodie.t ...... Dubious, test returned 2 (wstat 512, 0x200)
...
</pre>
