### PR TITLE
New property of spice and rewrite: accept_header

### DIFF
--- a/lib/DDG/Meta/ZeroClickInfoSpice.pm
+++ b/lib/DDG/Meta/ZeroClickInfoSpice.pm
@@ -20,7 +20,8 @@ sub zeroclickinfospice_attributes {qw(
 	proxy_ssl_session_reuse
 	to
 	wrap_jsonp_callback
-    wrap_string_callback
+	wrap_string_callback
+	accept_header
 	is_cached
 	is_unsafe
 	ttl
@@ -47,6 +48,7 @@ sub apply_keywords {
 		call => $path,
 		wrap_jsonp_callback => 0,
 		wrap_string_callback => 0,
+		accept_header => 0,
 	);
 
 	my $stash = Package::Stash->new($target);
@@ -57,6 +59,7 @@ sub apply_keywords {
 		delete $params{'to'};
 		delete $params{'wrap_jsonp_callback'};
 		delete $params{'wrap_string_callback'};
+		delete $params{'accept_header'};
 		delete $params{'proxy_cache_valid'};
 		delete $params{'proxy_ssl_session_reuse'};
 		return DDG::ZeroClickInfo::Spice->new(
@@ -160,6 +163,7 @@ sub apply_keywords {
 					path => $path,
 					wrap_jsonp_callback => $zcispice_params{'wrap_jsonp_callback'},
 					wrap_string_callback => $zcispice_params{'wrap_string_callback'},
+					accept_header => $zcispice_params{'accept_header'},
 				);
 			} else {
 				$rewrite = "";

--- a/lib/DDG/Rewrite.pm
+++ b/lib/DDG/Rewrite.pm
@@ -86,6 +86,11 @@ has wrap_string_callback => (
     default => sub { 0 },
 );
 
+has accept_header => (
+    is => 'ro',
+    default => sub { 0 },
+);
+
 has proxy_cache_valid => (
 	is => 'ro',
 	predicate => 'has_proxy_cache_valid',
@@ -119,6 +124,7 @@ sub _build_nginx_conf {
 	my $wrap_string_callback = $self->has_callback && $self->wrap_string_callback;
 
 	my $cfg = "location ^~ ".$self->path." {\n";
+	$cfg .= "\tproxy_set_header Accept '".$self->accept_header."';\n" if $self->accept_header;
 	$cfg .= "\techo_before_body '".$self->callback."(';\n" if $wrap_jsonp_callback;
 	$cfg .= "\techo_before_body '".$self->callback.qq|("';\n| if $wrap_string_callback;
 	$cfg .= "\trewrite ^".$self->path.($self->has_from ? $self->from : "(.*)")." ".$uri_path." break;\n";


### PR DESCRIPTION
To set the Accept: header for APIs requiring that, such as dx.doi.org, as required for, for example, https://github.com/duckduckgo/zeroclickinfo-spice/pull/119.

Corresponding duckpan pull request coming up as well.
