### PR TITLE
implement default caller value inside test_spice

### DIFF
--- a/lib/DDG/Test/Spice.pm
+++ b/lib/DDG/Test/Spice.pm
@@ -8,6 +8,7 @@ use Test::More;
 use DDG::Test::Block;
 use DDG::ZeroClickInfo::Spice;
 use Package::Stash;
+use Data::Dumper;
 
 =head1 DESCRIPTION
 
@@ -39,10 +40,10 @@ L<call of the DDG::ZeroClickInfo::Spice|DDG::ZeroClickInfo::Spice/call>
 	);
 
 	$stash->add_symbol('&test_spice', sub {
-		my $call = shift;
-		ref $_[0] eq 'HASH'
-			? DDG::ZeroClickInfo::Spice->new(%spice_params, %{$_[0]}, call => $call )
-			: DDG::ZeroClickInfo::Spice->new(%spice_params, @_, call => $call )
+		my ( $call, %opts ) = shift;
+		%opts = ref $_[0] eq 'HASH' ? %{$_[0]} : @_;
+		$opts{call_type} = 'include' if not defined $opts{call_type};
+		DDG::ZeroClickInfo::Spice->new(%spice_params, %opts, call => $call )
 	});
 
 =keyword spice


### PR DESCRIPTION
I took a look at the `test_spice` code as discussed in issue https://github.com/duckduckgo/duckduckgo/issues/39, and due to the current structure it does not seem possible to simply add a default for the `caller` as that information is out of scope inside `test_spice`. That said, I have implemented a default value for the `call_type`.
