### PR TITLE
Words.pm - Simplified Words Triggering

### DIFF
--- a/lib/DDG/Block/Words.pm
+++ b/lib/DDG/Block/Words.pm
@@ -218,8 +218,12 @@ sub request {
 				}
 			}
 
+			unless ( @hits ) {
+				$self->trace("No hit with","'".$word."'");
+			}
+
 			# iterate over each type of trigger match for the current word
-			# this allows us to consider multiple `start`, `end` and `any`
+			# this allows us to consider combinations of `start`, `end` and `any`
 			# triggers for the current word
 			while (my $hitref = shift @hits) {
 
@@ -298,7 +302,6 @@ sub request {
 					}
 				}
 			}
-			$self->trace("No hit with","'".$word."'");
 		}
 	}
 	return @results;

--- a/lib/DDG/Block/Words.pm
+++ b/lib/DDG/Block/Words.pm
@@ -170,32 +170,60 @@ sub request {
 		#
 		my $start = $cnt == 0 ? 1 : 0;
 		my $end = $cnt == $max-1 ? 1 : 0;
+
+		# Iterate over each word in the query, checking if any of
+		# the IA's have this specific word as (part of) a `start`,
+		# `end` or `any` trigger.
 		for my $word (@{$request->triggers->{$poses[$cnt]}}) {
 			$self->trace( "Testing word:", "'".$word."'" );
-			#
-			# Checking if any of the IA's have this specific word
-			# as (part of) a start, end or any trigger. Start and end
-			# of course only if its first or last word in the query.
-			#
-			# It gives back a touple of 2 elements, a bool which defines
-			# if there COULD BE more words after it (so this fits for
-			# any and start triggers), the second is the part of the
-			# prepared trigger set of the blocks which is responsible
-			# for this word.
-			#
-			# The keys inside the hitstruct define the words count it
-			# additional carries. This allows to kick out the ones which
-			# are not fitting anymore into the length of the query (by
-			# wordcount)
-			#
-			if (my ( $begin, $hitstruct ) =
-					$start && defined $self->_words_plugins->{start}->{$word}
-						? ( 1 => $self->_words_plugins->{start}->{$word} )
-						: $end && defined $self->_words_plugins->{end}->{$word}
-							? ( 0 => $self->_words_plugins->{end}->{$word} )
-							: defined $self->_words_plugins->{any}->{$word}
-								? ( 1 => $self->_words_plugins->{any}->{$word} )
-								: undef) {
+
+			my @hits = ();
+			{
+
+				# Flag that tells us if there could be more words
+				# after the matched word.
+				#
+				# Used for `any` and `start` triggers. Not for `end`
+				# triggers because they look in-front of the word.
+				my $begin = 0;
+
+				# A hash containing all triggers related to the current word
+				# 
+				# The keys inside the hitstruct define the word count for the
+				# trigger word/phrase. This is used to determine if the query
+				# is long enough to have a match.
+				# ie. a 2 word query can't match a 3 word trigger phrase
+				my $hitstruct = undef;
+
+				my $is_start = $start && defined $self->_words_plugins->{start}->{$word};
+				my $is_end = $end && defined $self->_words_plugins->{end}->{$word};
+				my $is_any = defined $self->_words_plugins->{any}->{$word};
+
+				if ($is_start) {
+					$begin = 1;
+					$hitstruct = $self->_words_plugins->{start}->{$word};
+					push(@hits,[$begin,$hitstruct]);
+				}
+
+				if ($is_end) {
+					$begin = 0;
+					$hitstruct = $self->_words_plugins->{end}->{$word};
+					push(@hits,[$begin,$hitstruct]);
+				}
+
+				if ($is_any) {
+					$begin = 1;
+					$hitstruct = $self->_words_plugins->{any}->{$word};
+					push(@hits,[$begin,$hitstruct]);
+				}
+			}
+
+			# iterate over each type of trigger match for the current word
+			# this allows us to consider multiple `start`, `end` and `any`
+			# triggers for the current word
+			while (my $hitref = shift @hits) {
+
+				my ($begin,$hitstruct) = @{$hitref};
 				######################################################
 				$self->trace("Got a hit with","'".$word."'","!", $begin ? "And it's just the beginning..." : "");
 
@@ -227,8 +255,8 @@ sub request {
 					}
 					# Here we take the index of the partially matched trigger phrase and
 					# calculate where the trigger should start or end (based on whether 
-					# it's a start or end trigger) to verify if the partial match is a
-					# full match against
+					# it's a `start` or `end` trigger) to verify if the partial match is a
+					# full match against the whole trigger
 					#
 					# Then we check if the next/previous word in the string matches
 					# the next/previous word in the trigger phrase (again, based on whether it's a start or end trigger)
@@ -269,9 +297,8 @@ sub request {
 						}
 					}
 				}
-			} else {
-				$self->trace("No hit with","'".$word."'");
 			}
+			$self->trace("No hit with","'".$word."'");
 		}
 	}
 	return @results;

--- a/t/50-spice.t
+++ b/t/50-spice.t
@@ -17,6 +17,7 @@ use DDGTest::Spice::Regexp;
 use DDGTest::Spice::Data;
 use DDGTest::Spice::Cached;
 use DDGTest::Spice::ChangeCached;
+use DDGTest::Spice::MultiTriggerType;
 
 use DDG::ZeroClickInfo::Spice;
 
@@ -69,6 +70,7 @@ ddg_spice_test(
 		DDGTest::Spice::Regexp
 		DDGTest::Spice::Cached
 		DDGTest::Spice::ChangeCached
+		DDGTest::Spice::MultiTriggerType
 	)],
 	'data test' => test_spice( 
 		'/js/spice/data/test',
@@ -98,6 +100,30 @@ ddg_spice_test(
 		call_type => 'include',
 		caller => 'DDGTest::Spice::ChangeCached',
 		is_cached => 0
+	),
+	'firstword secondword multitrigger test' => test_spice( 
+		'/js/spice/multi_trigger_type/multitrigger%20test',
+		call_type => 'include',
+		caller => 'DDGTest::Spice::MultiTriggerType',
+		is_cached => 1
+	),
+	'firstword multitrigger test' => test_spice( 
+		'/js/spice/multi_trigger_type/multitrigger%20test',
+		call_type => 'include',
+		caller => 'DDGTest::Spice::MultiTriggerType',
+		is_cached => 1
+	),
+	'multitrigger test secondword thirdword' => test_spice(  
+		'/js/spice/multi_trigger_type/multitrigger%20test',
+		call_type => 'include',
+		caller => 'DDGTest::Spice::MultiTriggerType',
+		is_cached => 1
+	),
+		'multitrigger test thirdword' => test_spice(  
+		'/js/spice/multi_trigger_type/multitrigger%20test',
+		call_type => 'include',
+		caller => 'DDGTest::Spice::MultiTriggerType',
+		is_cached => 1
 	),
 	# 'flash version' => test_spice( 
 	# 	'/js/spice/flashtest',

--- a/t/lib/DDGTest/Spice/MultiTriggerType.pm
+++ b/t/lib/DDGTest/Spice/MultiTriggerType.pm
@@ -1,0 +1,11 @@
+package DDGTest::Spice::MultiTriggerType;
+
+use DDG::Spice;
+
+triggers start => 'firstword secondword';
+triggers end => 'secondword thirdword';
+triggers any => 'firstword', 'thirdword';
+
+handle remainder => sub { shift; };
+
+1;


### PR DESCRIPTION
//cc @yegg @nilnilnil @russellholt 

While @yegg and I were trying to solve a potential triggering problem, we began refactoring a small portion of `Words.pm`. 

The triple ternary used to check for trigger matches has been simplified and now allows a fallback check against other trigger types that also matches against the current word. Therefore if an IA has both a `start` and `any` trigger that match against the current word, if the `start` trigger fails to match, the `any` trigger still has an opportunity to match. Before, only the first type of trigger that partially matched was checked and upon failure, the next word was considered.

Most of this fix was written by @yegg, I've provided the comments.