### PR TITLE
DDG/IsControllable: Set is_cached to 1 for both Spice and Goodies.

### DIFF
--- a/lib/DDG/IsControllable.pm
+++ b/lib/DDG/IsControllable.pm
@@ -17,7 +17,7 @@ anything else.
 
 has is_cached => (
 	is => 'ro',
-	default => sub { shift->isa("DDG::ZeroClickInfo::Spice") ? 1 : 0 },
+	default => 1,
 );
 
 =attr is_unsafe

--- a/t/35-block.t
+++ b/t/35-block.t
@@ -20,7 +20,7 @@ sub zci {
 	DDG::ZeroClickInfo->new(
 		answer => $answer,
 		answer_type => $answer_type,
-		is_cached => $is_cached ? 1 : 0,
+		is_cached => 1,
 		%extra_attributes,
 	);
 }


### PR DESCRIPTION
Before only Spice had is_cached set to 1. But since setting is_cached to 0 is more of the exeption in our IAs, it's better if is_cached is set to 1 as the default in Goodies as well.
