### PR TITLE
Structure

### DIFF
--- a/lib/DDG/IsStructurable.pm
+++ b/lib/DDG/IsStructurable.pm
@@ -1,0 +1,25 @@
+package DDG::IsStructurable;
+# ABSTRACT: Role for adding structured data to query results.
+
+use Moo::Role;
+
+requires qw(
+  structured_result
+);
+
+=head1 DESCRIPTION
+
+This role is used for classes which can return structured data in results for queries.
+
+=attr structured_result
+
+Indicates whether the package can provide a structured result.
+
+=cut
+
+has structured => (
+    is      => 'ro',
+    default => sub { 0 },
+);
+
+1;

--- a/lib/DDG/Meta/ZeroClickInfo.pm
+++ b/lib/DDG/Meta/ZeroClickInfo.pm
@@ -19,6 +19,7 @@ my %supported_zci_attributes = map { $_ => 1 } (qw(
       definition
       definition_source
       definition_url
+      structured
       type
       is_cached
       is_unsafe

--- a/lib/DDG/ZeroClickInfo.pm
+++ b/lib/DDG/ZeroClickInfo.pm
@@ -3,7 +3,6 @@ package DDG::ZeroClickInfo;
 
 use Moo;
 extends qw( WWW::DuckDuckGo::ZeroClickInfo );
-with 'DDG::IsControllable';
 
 =head1 SYNOPSIS
 
@@ -23,9 +22,12 @@ So far all required attributes get injected via L<DDG::IsControllable>.
 
 =cut
 
+has structured_result => (
+    is        => 'ro',
+    predicate => 1,
+);
 
-
-
+with 'DDG::IsControllable', 'DDG::IsStructurable';
 
 =head1 SEE ALSO
 


### PR DESCRIPTION
This is changeset attempts to allow DDG::ZeroClickInfo to contain a structured result.  The contents of that result are, as yet, undefined, but a merge is necssary to proceed on further goodies template work.
- Add a "structured" zci element to signal intent to return a structured result.
- Allow the return of the `structured_result` attribute
- Add the attribute in the `IsStructurable` role.

This is not my favorite way to do this, but it confroms with the general code layout and style to make progress for now.

//cc @russellholt
