### PR TITLE
Meta::Helper: be more calling-context aware.

### DIFF
--- a/lib/DDG/Meta/Helper.pm
+++ b/lib/DDG/Meta/Helper.pm
@@ -37,7 +37,7 @@ encodes entities to safely post random data on HTML output.
 
 =cut
 
-	$stash->add_symbol('&html_enc', sub { return (wantarray) ? map { encode_entities($_) } @_ : encode_entities($_[0]) });
+	$stash->add_symbol('&html_enc', sub { return (wantarray) ? map { encode_entities($_) } @_ : encode_entities(join '', @_) });
 
 =keyword uri_esc
 
@@ -50,7 +50,7 @@ values there, this will just lead to double encoding!
 
 =cut
 
-	$stash->add_symbol('&uri_esc', sub { return (wantarray) ? map { uri_escape($_) } @_ : uri_escape($_[0]) });
+	$stash->add_symbol('&uri_esc', sub { return (wantarray) ? map { uri_escape($_) } @_ : uri_escape(join '', @_) });
 
 }
 

--- a/t/14-meta-helpers.t
+++ b/t/14-meta-helpers.t
@@ -16,7 +16,7 @@ subtest 'html_enc' => sub {
         is($res, '&lt;', 'single input');
 
         $res = DDGTest::Goodie::MetaOnly::html_enc('>', '<');
-        is($res, '&gt;', 'multiple input gets first element');
+        is($res, '&gt;&lt;', 'multiple input gets concatenated elements');
     };
 
     subtest 'array output' => sub {
@@ -39,7 +39,7 @@ subtest 'uri_esc' => sub {
         is($res, '%3C', 'single input');
 
         $res = DDGTest::Goodie::MetaOnly::uri_esc('>', '<');
-        is($res, '%3E', 'multiple input gets first element');
+        is($res, '%3E%3C', 'multiple input gets concatenated elements');
     };
 
     subtest 'array output' => sub {


### PR DESCRIPTION
Since we're offering `html_enc` as an alternative to `encode_entities`
it should behave in the same way when supplied a scalar and expecting
scalar output.  Mostly we're concerned about when they want scalar
output, so we'll just encode the first element off the supplied array if
that's how they've called us.

`uri_esc` is similarly updated to provide similar semantics.

cc: @mintsoft
