### PR TITLE
dist.ini: updates to get Travis tests to pass.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
   - dzil listdeps | grep -ve '^\W' | cpanm  --quiet   --notest  --skip-installed
 language: perl
 perl:
-  - 5.10
+  - 5.14
   - 5.16
   - 5.18
 script:

--- a/dist.ini
+++ b/dist.ini
@@ -37,6 +37,7 @@ App::DuckPAN = 0.111
 WWW::DuckDuckGo = 0.015
 
 [Prereqs / TestRequires]
+Test::EOL = 0
 Test::Dirs = 0.03
 File::Temp = 0.22
 
@@ -64,8 +65,7 @@ version_regexp = ^(.+)$
 [PkgVersion]
 [PodSyntaxTests]
 [GithubMeta]
-[Repository]
-[EOLTests]
+[Test::EOL]
 trailing_whitespace = 0
 
 [@Git]
@@ -76,6 +76,6 @@ push_to = origin master
 
 [PodWeaver]
 [TravisCI]
-perl_version = 5.10
+perl_version = 5.14
 perl_version = 5.16
 perl_version = 5.18


### PR DESCRIPTION
- Move from perl 5.10 to 5.14
- Remove Repository plug-in in favor of GitHubMeta
- Switch EOLTests to Test::EOL and add dependency.
