### PR TITLE
Spice testing: allow matching `call` string against regular expression

### DIFF
--- a/lib/DDG/Test/Spice.pm
+++ b/lib/DDG/Test/Spice.pm
@@ -9,8 +9,6 @@ use DDG::Test::Block;
 use DDG::ZeroClickInfo::Spice;
 use Package::Stash;
 
-use Data::Printer;
-
 =head1 DESCRIPTION
 
 Installs functions for testing Spice.

--- a/lib/DDG/Test/Spice.pm
+++ b/lib/DDG/Test/Spice.pm
@@ -9,6 +9,8 @@ use DDG::Test::Block;
 use DDG::ZeroClickInfo::Spice;
 use Package::Stash;
 
+use Data::Printer;
+
 =head1 DESCRIPTION
 
 Installs functions for testing Spice.
@@ -83,10 +85,14 @@ testing your L<DDG::Spice> alone or in combination with others.
 =cut
 
 	$stash->add_symbol('&ddg_spice_test', sub { block_test(sub {
-		my $query = shift;
-		my $answer = shift;
-		my $spice = shift;
+		my ($query, $answer, $spice) = @_;
+
 		if ($answer) {
+			if (ref $spice->{call} eq 'Regexp') {
+				like($answer->{call}, $spice->{call}, 'Regexp: ' . $spice->{call} );
+				$spice->{call} = $answer->{call};
+			}
+
 			is_deeply($answer,$spice,'Testing query '.$query);
 		} else {
 			fail('Expected result but dont get one on '.$query);

--- a/t/50-spice.t
+++ b/t/50-spice.t
@@ -72,36 +72,42 @@ ddg_spice_test(
 		DDGTest::Spice::Cached
 		DDGTest::Spice::ChangeCached
 	)],
-	'data test' => test_spice( 
+	'data test' => test_spice(
 		'/js/spice/data/test',
 		call_data => { otherkey => 'value', key => 'finalvalue' },
 		call_type => 'include',
 		caller => 'DDGTest::Spice::Data'
 	),
-	'bregexp test a' => test_spice( 
+	'data test regex' => test_spice(
+		qr!/js/spice/data/\w+%20\w+!,
+		call_data => { otherkey => 'value', key => 'finalvalue' },
+		call_type => 'include',
+		caller => 'DDGTest::Spice::Data'
+	),
+	'bregexp test a' => test_spice(
 		'/js/spice/regexp/test.a/DDG%3A%3ARequest',
 		call_type => 'include',
 		caller => 'DDGTest::Spice::Regexp'
 	),
-	'testing cached' => test_spice( 
+	'testing cached' => test_spice(
 		'/js/spice/cached/testing',
 		call_type => 'include',
 		caller => 'DDGTest::Spice::Cached',
 		is_cached => 1
 	),
-	'test changed caching' => test_spice( 
+	'test changed caching' => test_spice(
 		'/js/spice/change_cached/test',
 		call_type => 'include',
 		caller => 'DDGTest::Spice::ChangeCached',
 		is_cached => 1
 	),
-	'not caching changed caching' => test_spice( 
+	'not caching changed caching' => test_spice(
 		'/js/spice/change_cached/not%20caching',
 		call_type => 'include',
 		caller => 'DDGTest::Spice::ChangeCached',
 		is_cached => 0
 	),
-	# 'flash version' => test_spice( 
+	# 'flash version' => test_spice(
 	# 	'/js/spice/flashtest',
 	# 	call_type => 'self',
 	# 	caller => 'DDGTest::Spice::Flashtest'


### PR DESCRIPTION
Allow for a testing the Spice's `call` against a regex instead of just a string comparison. This will make it much easier to test certain, dynamic Spices, such as those that are time dependent.

I guess we haven't previously needed this functionality but it seemed like it might be necessary to test the new Flights IA (https://github.com/duckduckgo/zeroclickinfo-spice/pull/1271)

//cc @mwmiller @jagtalon 
