### PR TITLE
Allow PkgVersion to set the version, DuckPAN will default to 9.999 if  isn't defined

### DIFF
--- a/lib/DDG.pm
+++ b/lib/DDG.pm
@@ -11,8 +11,6 @@ Longtime it will get probably a kind of metaclass or stays a general configurati
 use strict;
 use warnings;
 
-our $VERSION ||= '9.999';
-
 use File::ShareDir::ProjectDistDir;
 
 use Exporter 'import';


### PR DESCRIPTION
/cc @russellholt @jagtalon @jbarrett 

This will create the same problems DuckPAN face and isn't needed with the changes to DuckPAN: https://github.com/duckduckgo/p5-app-duckpan/pull/209

Only devs actively working on this repo should ever be running the DDG code "in-place" so this shouldn't affect anyone.