### PR TITLE
DDG::Meta::CountryCodes - Centralize aliasing/renaming

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -10,7 +10,7 @@ module = Dist::Zilla::Plugin::UploadToDuckPAN
 
 [AutoPrereqs]
 [Prereqs]
-Data::Printer
+Data::Printer = 0
 
 [GatherDir]
 [PruneCruft]

--- a/dist.ini
+++ b/dist.ini
@@ -8,38 +8,7 @@ copyright_year   = 2013
 index = http://duckpan.org
 module = Dist::Zilla::Plugin::UploadToDuckPAN
 
-[Prereqs]
-Class::Load = 0.18
-Data::Printer = 0.3
-Digest::MD5 = 2.51
-File::Path = 2.08
-File::ShareDir = 1.03
-File::ShareDir::ProjectDistDir = 0.2.0
-File::Spec = 3.33
-IO::All = 0.41
-JSON = 2.53
-List::MoreUtils = 0.33
-HTML::Entities = 3.69
-Module::Data = 0.001
-Module::Runtime = 0.013
-Moo = 0.091004
-MooX = 0.101
-namespace::autoclean = 0.13
-Package::Stash = 0.33
-Path::Class = 0.25
-Test::More = 0.98
-URI = 1.60
-URI::Encode = 0.061
-utf8::all = 0.004
-YAML = 0.73
-YAML::XS = 0.35
-App::DuckPAN = 0.111
-WWW::DuckDuckGo = 0.015
-
-[Prereqs / TestRequires]
-Test::EOL = 0
-Test::Dirs = 0.03
-File::Temp = 0.22
+[AutoPrereqs]
 
 [GatherDir]
 [PruneCruft]
@@ -76,6 +45,4 @@ push_to = origin master
 
 [PodWeaver]
 [TravisCI]
-perl_version = 5.14
 perl_version = 5.16
-perl_version = 5.18

--- a/dist.ini
+++ b/dist.ini
@@ -9,8 +9,6 @@ index = http://duckpan.org
 module = Dist::Zilla::Plugin::UploadToDuckPAN
 
 [AutoPrereqs]
-[Prereqs]
-Data::Printer = 0
 
 [GatherDir]
 [PruneCruft]

--- a/dist.ini
+++ b/dist.ini
@@ -9,6 +9,8 @@ index = http://duckpan.org
 module = Dist::Zilla::Plugin::UploadToDuckPAN
 
 [AutoPrereqs]
+[Prereqs]
+Data::Printer
 
 [GatherDir]
 [PruneCruft]

--- a/dist.ini
+++ b/dist.ini
@@ -36,8 +36,6 @@ version_regexp = ^(.+)$
 [PkgVersion]
 [PodSyntaxTests]
 [GithubMeta]
-[Test::EOL]
-trailing_whitespace = 0
 
 [@Git]
 tag_format = %v

--- a/lib/DDG/Meta.pm
+++ b/lib/DDG/Meta.pm
@@ -4,6 +4,7 @@ package DDG::Meta;
 use strict;
 use warnings;
 use Carp;
+require Data::Printer;
 
 use DDG::Meta::RequestHandler;
 use DDG::Meta::ZeroClickInfo;

--- a/lib/DDG/Meta.pm
+++ b/lib/DDG/Meta.pm
@@ -14,6 +14,7 @@ use DDG::Meta::Block;
 use DDG::Meta::Information;
 use DDG::Meta::Helper;
 use DDG::Meta::AnyBlock;
+use DDG::Meta::CountryCodes;
 
 use MooX ();
 

--- a/lib/DDG/Meta/CountryCodes.pm
+++ b/lib/DDG/Meta/CountryCodes.pm
@@ -3,11 +3,9 @@ package DDG::Meta::CountryCodes;
 
 use Locale::Country 'country2code';;
 
-unless(country2code('Tobago')){
+unless(country2code('DuckDuckGo')){
     # These are the only 2 countries which officially have 'The' in their name
     # Source: http://www.bbc.co.uk/news/magazine-18233844
-    Locale::Country::rename_country('gm' => 'The Gambia');
-    Locale::Country::rename_country('bs' => 'The Bahamas');
     Locale::Country::add_country_alias('Antigua and Barbuda' => 'Antigua');
     Locale::Country::add_country_alias('Antigua and Barbuda' => 'Barbuda');
     Locale::Country::add_country_alias("Lao People's Democratic Republic" => "Laos");
@@ -35,6 +33,12 @@ unless(country2code('Tobago')){
     Locale::Country::rename_country('va' => 'the Holy See (Vatican City State)');
     Locale::Country::rename_country('vg' => 'the British Virgin Islands');
     Locale::Country::rename_country('vi' => 'the US Virgin Islands');
+    # Easter eggs
+    Locale::Country::add_country_alias('Russian Federation' => 'Kremlin');
+    Locale::Country::add_country_alias('United States' => 'murica');
+    Locale::Country::add_country_alias('Canada' => 'Canadia');
+    Locale::Country::add_country_alias('Australia' => 'down under');
+    Locale::Country::add_country_alias('Canada' => 'DuckDuckGo');
 }
 
 1;

--- a/lib/DDG/Meta/CountryCodes.pm
+++ b/lib/DDG/Meta/CountryCodes.pm
@@ -1,0 +1,40 @@
+package DDG::Meta::CountryCodes;
+# ABSTRACT: Master list of country renames and aliases for all IAs
+
+use Locale::Country 'country2code';;
+
+unless(country2code('Tobago')){
+    # These are the only 2 countries which officially have 'The' in their name
+    # Source: http://www.bbc.co.uk/news/magazine-18233844
+    Locale::Country::rename_country('gm' => 'The Gambia');
+    Locale::Country::rename_country('bs' => 'The Bahamas');
+    Locale::Country::add_country_alias('Antigua and Barbuda' => 'Antigua');
+    Locale::Country::add_country_alias('Antigua and Barbuda' => 'Barbuda');
+    Locale::Country::add_country_alias("Lao People's Democratic Republic" => "Laos");
+    Locale::Country::add_country_alias('Russian Federation' => 'Russia');
+    Locale::Country::add_country_alias('Trinidad and Tobago' => 'Tobago');
+    Locale::Country::add_country_alias('Trinidad and Tobago' => 'Trinidad');
+    Locale::Country::add_country_alias('Vatican City' => 'Vatican');
+    Locale::Country::add_country_alias('Virgin Islands, U.S.' => 'US Virgin Islands');
+    # Source: http://www.bbc.co.uk/news/magazine-18233844
+    Locale::Country::add_country_alias('United States' => 'America');
+    Locale::Country::rename_country('ae' => 'the United Arab Emirates');
+    Locale::Country::rename_country('bs' => 'The Bahamas');
+    Locale::Country::rename_country('do' => 'the Dominican Republic');
+    Locale::Country::rename_country('gb' => 'the United Kingdom');
+    Locale::Country::rename_country('gm' => 'The Gambia');
+    Locale::Country::rename_country('kp' => "the Democratic People's Republic of Korea"); # North Korea
+    Locale::Country::rename_country('kr' => "the Republic of Korea"); # South Korea
+    Locale::Country::rename_country('ky' => 'the Cayman Islands');
+    Locale::Country::rename_country('mp' => 'the Northern Mariana Islands');
+    Locale::Country::rename_country('nl' => 'the Netherlands');
+    Locale::Country::rename_country('ph' => 'the Philippines');
+    Locale::Country::rename_country('ru' => 'the Russian Federation');
+    Locale::Country::rename_country('tw' => 'Taiwan');
+    Locale::Country::rename_country('us' => 'the United States');
+    Locale::Country::rename_country('va' => 'the Holy See (Vatican City State)');
+    Locale::Country::rename_country('vg' => 'the British Virgin Islands');
+    Locale::Country::rename_country('vi' => 'the US Virgin Islands');
+}
+
+1;


### PR DESCRIPTION
This is an alternative approach to https://github.com/duckduckgo/duckduckgo/pull/108 to centralize the renaming and aliasing of country codes to prevent warnings.  It tries to be minimal, allowing IAs to still use Locale::Country functions.

Are we ok with these renames?  I don't know the history behind them but I'm guessing it's so they are readable when displayed.

This needs to go with PRs [#1103](https://github.com/duckduckgo/zeroclickinfo-goodies/pull/1103) and [#1755](https://github.com/duckduckgo/zeroclickinfo-spice/pull/1755) if we decide to move forward with it.

/cc @nilnilnil 