### PR TITLE
Add DDG::Meta::Data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,16 @@
 ---
 sudo: false
+addons:
+  apt_packages:
+    - libmpfr-dev
 before_install:
   - export HARNESS_OPTIONS=j10:c HARNESS_TIMER=1
-  - rm .travis.yml
   - git config --global user.name "Dist Zilla Plugin TravisCI"
   - git config --global user.email $HOSTNAME":not-for-mail@travis-ci.org"
 install:
-  - cpanm  --quiet  --notest --skip-installed Dist::Zilla
-  - dzil authordeps | grep -ve '^\W' | xargs -n 5 -P 10 cpanm  --quiet   --notest  --skip-installed
-  - dzil listdeps | grep -ve '^\W' | cpanm  -v   --notest  --skip-installed --mirror http://www.cpan.org/ --mirror http://duckpan.org
+  - cpanm --quiet --notest Dist::Zilla
+  - dzil authordeps | grep -ve '^\W' | xargs -n 5 -P 10 cpanm --quiet --notest
+  - dzil listdeps | grep -ve '^\W' | cpanm --quiet --notest --mirror http://www.cpan.org/ --mirror http://duckpan.org
 language: perl
 perl:
   - '5.16'

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ install:
   - dzil listdeps | grep -ve '^\W' | cpanm  --quiet   --notest  --skip-installed
 language: perl
 perl:
-  - 5.14
-  - 5.16
-  - 5.18
+  - '5.16'
 script:
   - dzil smoke --release --author

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
 install:
   - cpanm  --quiet  --notest --skip-installed Dist::Zilla
   - dzil authordeps | grep -ve '^\W' | xargs -n 5 -P 10 cpanm  --quiet   --notest  --skip-installed
-  - dzil listdeps | grep -ve '^\W' | cpanm  --quiet   --notest  --skip-installed --mirror http://www.cpan.org/ --mirror http://duckpan.org
+  - dzil listdeps | grep -ve '^\W' | cpanm  -v   --notest  --skip-installed --mirror http://www.cpan.org/ --mirror http://duckpan.org
 language: perl
 perl:
   - '5.16'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 ---
+sudo: false
 before_install:
   - export HARNESS_OPTIONS=j10:c HARNESS_TIMER=1
   - rm .travis.yml
@@ -7,7 +8,7 @@ before_install:
 install:
   - cpanm  --quiet  --notest --skip-installed Dist::Zilla
   - dzil authordeps | grep -ve '^\W' | xargs -n 5 -P 10 cpanm  --quiet   --notest  --skip-installed
-  - dzil listdeps | grep -ve '^\W' | cpanm  --quiet   --notest  --skip-installed
+  - dzil listdeps | grep -ve '^\W' | cpanm  --quiet   --notest  --skip-installed --mirror http://www.cpan.org/ --mirror http://duckpan.org
 language: perl
 perl:
   - '5.16'

--- a/dist.ini
+++ b/dist.ini
@@ -8,6 +8,8 @@ copyright_year   = 2013
 index = http://duckpan.org
 module = Dist::Zilla::Plugin::UploadToDuckPAN
 
+[Prereqs]
+DateTime::Astro = 0
 [AutoPrereqs]
 
 [GatherDir]

--- a/dist.ini
+++ b/dist.ini
@@ -8,8 +8,6 @@ copyright_year   = 2013
 index = http://duckpan.org
 module = Dist::Zilla::Plugin::UploadToDuckPAN
 
-[Prereqs]
-DateTime::Astro = 0
 [AutoPrereqs]
 
 [GatherDir]

--- a/dist.ini
+++ b/dist.ini
@@ -8,38 +8,7 @@ copyright_year   = 2013
 index = http://duckpan.org
 module = Dist::Zilla::Plugin::UploadToDuckPAN
 
-[Prereqs]
-Class::Load = 0.18
-Data::Printer = 0.3
-Digest::MD5 = 2.51
-File::Path = 2.08
-File::ShareDir = 1.03
-File::ShareDir::ProjectDistDir = 0.2.0
-File::Spec = 3.33
-IO::All = 0.41
-JSON = 2.53
-List::MoreUtils = 0.33
-HTML::Entities = 3.69
-Module::Data = 0.001
-Module::Runtime = 0.013
-Moo = 0.091004
-MooX = 0.101
-namespace::autoclean = 0.13
-Package::Stash = 0.33
-Path::Class = 0.25
-Test::More = 0.98
-URI = 1.60
-URI::Encode = 0.061
-utf8::all = 0.004
-YAML = 0.73
-YAML::XS = 0.35
-App::DuckPAN = 0.111
-WWW::DuckDuckGo = 0.015
-
-[Prereqs / TestRequires]
-Test::EOL = 0
-Test::Dirs = 0.03
-File::Temp = 0.22
+[AutoPrereqs]
 
 [GatherDir]
 [PruneCruft]
@@ -56,17 +25,12 @@ File::Temp = 0.22
 
 [MetaNoIndex]
 directory = t/
-directory = xt/
-directory = ex/
-directory = inc/
 
 [Git::NextVersion]
 version_regexp = ^(.+)$
 [PkgVersion]
 [PodSyntaxTests]
 [GithubMeta]
-[Test::EOL]
-trailing_whitespace = 0
 
 [@Git]
 tag_format = %v
@@ -75,7 +39,3 @@ tag_format = %v
 push_to = origin master
 
 [PodWeaver]
-[TravisCI]
-perl_version = 5.14
-perl_version = 5.16
-perl_version = 5.18

--- a/lib/DDG/Meta.pm
+++ b/lib/DDG/Meta.pm
@@ -118,6 +118,7 @@ sub apply_fathead_keywords {
 	DDG::Meta::ShareDir->apply_keywords($target);
     DDG::Meta::Fathead->apply_keywords($target);
     DDG::Meta::Information->apply_keywords($target);    
+	DDG::Meta::Data->apply_keywords($target);
     DDG::Meta::AnyBlock->apply_keywords($target);
     Moo::Role->apply_role_to_package($target, "DDG::IsFathead");
 }
@@ -131,6 +132,7 @@ sub apply_longtail_keywords {
     DDG::Meta::ZeroClickInfo->apply_keywords($target);
 	DDG::Meta::ShareDir->apply_keywords($target);
     DDG::Meta::Information->apply_keywords($target);
+	DDG::Meta::Data->apply_keywords($target);
     DDG::Meta::AnyBlock->apply_keywords($target);
     Moo::Role->apply_role_to_package($target, "DDG::IsLongtail");
 }

--- a/lib/DDG/Meta.pm
+++ b/lib/DDG/Meta.pm
@@ -115,10 +115,10 @@ sub apply_spice_keywords {
 sub apply_fathead_keywords {
     my ( $class, $target ) = @_;
     DDG::Meta::ZeroClickInfo->apply_keywords($target);
-	DDG::Meta::ShareDir->apply_keywords($target);
+    DDG::Meta::ShareDir->apply_keywords($target);
     DDG::Meta::Fathead->apply_keywords($target);
     DDG::Meta::Information->apply_keywords($target);    
-	DDG::Meta::Data->apply_keywords($target);
+    DDG::Meta::Data->apply_keywords($target);
     DDG::Meta::AnyBlock->apply_keywords($target);
     Moo::Role->apply_role_to_package($target, "DDG::IsFathead");
 }
@@ -130,9 +130,9 @@ sub apply_fathead_keywords {
 sub apply_longtail_keywords {
     my ( $class, $target ) = @_;
     DDG::Meta::ZeroClickInfo->apply_keywords($target);
-	DDG::Meta::ShareDir->apply_keywords($target);
+    DDG::Meta::ShareDir->apply_keywords($target);
     DDG::Meta::Information->apply_keywords($target);
-	DDG::Meta::Data->apply_keywords($target);
+    DDG::Meta::Data->apply_keywords($target);
     DDG::Meta::AnyBlock->apply_keywords($target);
     Moo::Role->apply_role_to_package($target, "DDG::IsLongtail");
 }

--- a/lib/DDG/Meta.pm
+++ b/lib/DDG/Meta.pm
@@ -14,6 +14,7 @@ use DDG::Meta::Block;
 use DDG::Meta::Information;
 use DDG::Meta::Helper;
 use DDG::Meta::AnyBlock;
+use DDG::Meta::Data;
 
 use MooX ();
 
@@ -70,6 +71,7 @@ sub apply_goodie_keywords {
 	DDG::Meta::ShareDir->apply_keywords($target);
 	DDG::Meta::Block->apply_keywords($target);
 	DDG::Meta::Information->apply_keywords($target);
+	DDG::Meta::Data->apply_keywords($target);
 	DDG::Meta::Helper->apply_keywords($target);
 	DDG::Meta::RequestHandler->apply_keywords($target,sub {
 		shift->zci_new(
@@ -99,6 +101,7 @@ sub apply_spice_keywords {
 	DDG::Meta::ShareDir->apply_keywords($target);
 	DDG::Meta::Block->apply_keywords($target);
 	DDG::Meta::Information->apply_keywords($target);
+	DDG::Meta::Data->apply_keywords($target);
 	DDG::Meta::Helper->apply_keywords($target);
 	DDG::Meta::RequestHandler->apply_keywords($target,sub {
 		shift->spice_new(@_);

--- a/lib/DDG/Meta/Data.pm
+++ b/lib/DDG/Meta/Data.pm
@@ -8,6 +8,7 @@ use JSON::XS 'decode_json';
 use Path::Class;
 use File::ShareDir 'dist_file';
 use IO::All;
+use Clone 'clone';
 
 sub debug { 0 }
 use if debug, 'Data::Printer';
@@ -96,7 +97,7 @@ sub apply_keywords {
 
     my $ia;
     unless($ia = $self->get_ia(module => $target)){
-        warn "No metadata found for $target"; 
+        warn "No metadata found for $target";
         return;
     }
 
@@ -115,15 +116,14 @@ sub get_ia {
     $lookup =~ s/^DDG::Goodie::IsAwesome\K::.+$//;
 
     # make a copy of the hash; doesn't need deep cloning atm
-    my %ia = %{$ia_metadata{$by}{$lookup}};
-    warn 'Returning IA ', p(%ia) if debug;
-    return \%ia;
+    my $m = $ia_metadata{$by}{$lookup};
+    warn 'Returning IA ', p($m) if debug;
+    return $m ? clone($m) : $m;
 }
 
 # return a hash of IA objects by id
 sub by_id {
-    my %h = %{$ia_metadata{id}};
-    return \%h;
+    return clone($ia_metadata{id});
 }
 
 # Internal function.

--- a/lib/DDG/Meta/Data.pm
+++ b/lib/DDG/Meta/Data.pm
@@ -76,7 +76,7 @@ unless(%ia_metadata){
                 tab => $module_data->{tab},
                 perl_module => $perl_module,
                 topic => $module_data->{topic},
-                js_callback_name => $self->js_callback_name($perl_module)
+                js_callback_name => _js_callback_name($perl_module)
             };
 
             #add new ia to ia_metadata{id}
@@ -126,8 +126,9 @@ sub by_id {
     return \%h;
 }
 
-sub js_callback_name {                                                                                                                                                                                                                                                                                             
-    my ($self, $name) = @_;
+# Internal function.
+sub _js_callback_name {
+    my $name = shift;
     my $fn;
     if(($fn) = $name =~ /^DDG::\w+::(\w.+)$/o){
         $fn =~ s/::/_/og;

--- a/lib/DDG/Meta/Data.pm
+++ b/lib/DDG/Meta/Data.pm
@@ -58,7 +58,6 @@ sub build_metadata {
             my $sharedir = $self->_make_sharedir($perl_module);
 
             # create a new ia
-			warn "Adding $perl_module\n";
             $ia_metadata{$perl_module} = {
                 id => $module_data->{id},
                 signal_from => $module_data->{signal_from} || $module_data->{id},
@@ -86,7 +85,7 @@ sub apply_keywords {
 
 	return if exists $applied{$target};	
 
-	$ia_metadata = $self->build_metadata unless %ia_metadata;
+	$self->build_metadata unless %ia_metadata;
 
 	warn "No metadata found for $target", return unless my $ia = $ia_metadata{$target};
 

--- a/lib/DDG/Meta/Data.pm
+++ b/lib/DDG/Meta/Data.pm
@@ -1,7 +1,6 @@
 package DDG::Meta::Data;
 # ABSTRACT: Metadata functions for instant answers
 
-use Moo;
 use DDG::SpiceBundle::OpenSourceDuckDuckGo; 
 use DDG::GoodieBundle::OpenSourceDuckDuckGo; 
 use DDG::LongtailBundle::OpenSourceDuckDuckGo; 

--- a/lib/DDG/Meta/Data.pm
+++ b/lib/DDG/Meta/Data.pm
@@ -70,27 +70,14 @@ unless(%ia_metadata){
                 warn "Duplicate ID for IA with ID: $id";
             }
 
-            my $perl_module = $module_data->{perl_module};
-
-            # create a new ia
-            my $ia = {
-                id => $module_data->{id},
-                signal_from => $module_data->{signal_from} || $module_data->{id},
-                status => $module_data->{status},
-                example_query => $module_data->{example_query},
-                name => $module_data->{name},
-                description => $module_data->{description},
-                repo => $module_data->{repo},
-                tab => $module_data->{tab},
-                perl_module => $perl_module,
-                topic => $module_data->{topic},
-                js_callback_name => _js_callback_name($perl_module)
-            };
+            # Clean up/set some values
+            $module_data->{signal_from} ||= $module_data->{id};
+            $module_data->{js_callback_name} = _js_callback_name($module_data->{perl_module});
 
             #add new ia to ia_metadata{id}
-            $ia_metadata{id}{$id} = $ia;
+            $ia_metadata{id}{$id} = $module_data;
             #add new ia to ia_metadata{module}. Multiple ias per module possible
-            push @{$ia_metadata{module}{$perl_module}}, $ia;
+            push @{$ia_metadata{module}{$perl_module}}, $module_data;
         }
     }
 }

--- a/lib/DDG/Meta/Data.pm
+++ b/lib/DDG/Meta/Data.pm
@@ -70,9 +70,11 @@ unless(%ia_metadata){
                 warn "Duplicate ID for IA with ID: $id";
             }
 
+            my $perl_module = $module_data->{perl_module};
+
             # Clean up/set some values
             $module_data->{signal_from} ||= $module_data->{id};
-            $module_data->{js_callback_name} = _js_callback_name($module_data->{perl_module});
+            $module_data->{js_callback_name} = _js_callback_name($perl_module);
 
             #add new ia to ia_metadata{id}
             $ia_metadata{id}{$id} = $module_data;

--- a/lib/DDG/Meta/Data.pm
+++ b/lib/DDG/Meta/Data.pm
@@ -52,8 +52,8 @@ unless(%ia_metadata){
             #next unless $module_data->{status} eq 'live';
 
             # check for bad metadata.  We need a perl_module for the by_module key
-            if($module_data->{perl_module} !~ /DDG::.+::.+/){
-                warn "Something wrong with perl_module for IA $id perl_module: $module_data->{perl_module} in $filename ...  Not fatal but the IA won't show";
+            if($module_data->{perl_module} !~ /DDG::.+::.+/ and $module_data->{status} eq 'live'){
+                warn "Invalid perl_module for IA $id: $module_data->{perl_module} in $filename...skipping";
                 next IA;
             }
 

--- a/lib/DDG/Meta/Data.pm
+++ b/lib/DDG/Meta/Data.pm
@@ -90,7 +90,7 @@ unless(%ia_metadata){
             #add new ia to ia_metadata{id}
             $ia_metadata{id}{$id} = $ia;
             #add new ia to ia_metadata{module}. Multiple ias per module possible
-            $ia_metadata{module}{$perl_module} = $ia;
+            push @{$ia_metadata{module}{$perl_module}}, $ia;
         }
     }
 }
@@ -102,19 +102,51 @@ sub apply_keywords {
 
     return if $applied{$target};    
 
-    my $ia;
-    unless($ia = $self->get_ia(module => $target)){
+    my $ias;
+    unless($ias = $self->get_ia(module => $target)){
         warn "No metadata found for $target" if debug;
         return;
     }
+    # If only one id this will be false. Only a few IAs have
+    # multiple ids per module, e.g. CheatSheets
+    my $id_required = @{$ias} - 1;
 
     my $s = Package::Stash->new($target);
 
-    while(my ($k, $v) = each %$ia){
-        $s->add_symbol("&$k", sub { $v });
-    }
+    # Will return metadata by id from the current subset of the IA's metadata
+    my $dynamic_meta = sub {
+        my $id = $_[0];
+        unless($id){
+            die "No id provided to dynamic instant answer";
+        }
+        my @m = grep {$_->{id} eq $id} @$ias;
+        unless(@m == 1){
+            die "Failed to select metadata with id $id";
+        }
+        return $m[0];
+    };
 
-    $s->add_symbol('&metadata', sub { return clone($ia) });
+    # Check for id_required *outside* of the subs so we don't incur the
+    # slight performance penalty across the board. Remember that these
+    # are method calls and that $_[0] is self
+    while(my ($k, $v) = each %{$ias->[0]}){ # must have at least one set of metadata
+        $s->add_symbol("&$k", $id_required ? 
+            sub {
+                my $m = $dynamic_meta->($_[1]);
+                return $m->{$k};
+            }
+            :
+            sub { $v }
+        );
+    }
+    $s->add_symbol('&metadata', $id_required ? 
+        sub {
+            my $m = $dynamic_meta->($_[1]);
+            return clone($m);
+        }
+        :
+        sub { clone($ias->[0]) }
+    );
 }
 
 sub get_ia {

--- a/lib/DDG/Meta/Data.pm
+++ b/lib/DDG/Meta/Data.pm
@@ -118,7 +118,7 @@ sub get_ia {
     # make a copy of the hash; doesn't need deep cloning atm
     my $m = $ia_metadata{$by}{$lookup};
     warn 'Returning IA ', p($m) if debug;
-    return $m ? clone($m) : $m;
+    return clone($m);
 }
 
 # return a hash of IA objects by id

--- a/lib/DDG/Meta/Data.pm
+++ b/lib/DDG/Meta/Data.pm
@@ -1,0 +1,135 @@
+package DDG::Meta::Data;
+use Package::Stash;
+use DDG::Util::Database qw( decode_json_file );
+use Path::Class;
+
+sub debug { 0 }
+use if debug, 'Data::Printer';
+
+no warnings 'uninitialized';
+
+# perl library for IA metadata
+my $perl5_dir = '/usr/local/ddg.cpan/perl5/lib/perl5/auto/share/module';
+my $ddg_cache = $ENV{DDG_CACHE_DIR};
+
+# $ia_metadata => {
+#    id => { ... }
+#    module => { ... }
+#    sharedir => { ... }
+# }
+my %ia_metadata;
+
+my %metadata_files = map { $_ => "$perl5_dir/DDG-$_-Meta/metadata.json" } qw(Goodie Spice Fathead Longtail);
+
+sub build_metadata {
+    my $self = shift;
+
+    FILE: while (my ($type, $filename) = each %metadata_files) {
+	warn "loading $filename";
+        warn "IA type: $type Version: $versions{$type}" if debug;
+
+        # One metadata file for each repo with the following format
+        # { "<IA name>": {
+        #     "id": " " 
+        #     "signal" : " "
+        #     ....
+        # }
+        my $file_data = decode_json_file($filename);
+
+        # check for decode_json_file error, returns undef
+        warn "reading metadata file failed ... $filename" unless $file_data;
+
+        IA: while (my ($id, $module_data) = each %{ $file_data }) {
+
+            # check for bad metadata.  We need a perl_module for the by_module key
+            if($module_data->{perl_module} !~ /DDG::.+::.+/){
+                warn "Something wrong with perl_module for IA $id perl_module: $module_data->{perl_module} in $filename ...  Not fatal but the IA won't show";
+                next IA;
+            }
+
+            # generic IsAwesome goodie metadata since these are always the same
+            if($module_data->{perl_module} =~ /IsAwesome/){
+                next IA if $ia_metadata{module}{'DDG::Goodie::IsAwesome'};
+                $module_data->{id} = 'is_awesome';
+                $module_data->{perl_module} = 'DDG::Goodie::IsAwesome'
+            }
+
+            my $perl_module = $module_data->{perl_module};
+            my $sharedir = $self->_make_sharedir($perl_module);
+
+            # create a new ia
+			warn "Adding $perl_module\n";
+            $ia_metadata{$perl_module} = {
+                id => $module_data->{id},
+                signal_from => $module_data->{signal_from} || $module_data->{id},
+                status => $module_data->{status},
+                example_query => $module_data->{example_query},
+                name => $module_data->{name},
+                description => $module_data->{description},
+                repo => $module_data->{repo},
+                tab => $module_data->{tab},
+                perl_module => $perl_module,
+                sharedir => $sharedir,
+                sharedir_abs => $self->_make_sharedir_abs($sharedir),
+                topic => $module_data->{topic},
+                js_callback_name => $self->js_callback_name($perl_module)
+            };
+
+        }
+    }
+}
+
+my %applied;
+
+sub apply_keywords {
+	my ($self, $target) = @_;
+
+	return if exists $applied{$target};	
+
+	$ia_metadata = $self->build_metadata unless %ia_metadata;
+
+	warn "No metadata found for $target", return unless my $ia = $ia_metadata{$target};
+
+	my $s = Package::Stash->new($target);
+
+	while(my ($k, $v) = each %$ia){
+		$s->add_symbol("&$k", sub { $v });
+	}
+	$s->add_symbol('&metadata', sub { $ia });
+}
+
+# get share directory path from perl module
+sub _make_sharedir {
+    my ($self, $class) = @_;
+    my @classparts = grep{$_ ne 'DDG'} split('::', $class);
+    my $v = $versions{ ucfirst $classparts[0]} || 0;
+    my $sharedir = join('/', (map { s/([a-z])([A-Z])/$1_$2/g; lc } @classparts), $v);
+    return $sharedir;
+}
+
+sub _make_sharedir_abs {
+    my ($self, $sharedir) = @_;
+    my $dir = dir($ddg_cache, 'share', $sharedir);
+    return $dir;
+}
+
+# convert decimal and string version to int ex:  0.002 => 2
+sub _convert_version {
+    my ($v) = @_;
+    $v =~ s/[^\d]+//g;
+    $v += 0;
+    return $v
+}
+
+sub js_callback_name {                                                                                                                                                                                                                                                                                             
+    my ($self, $name) = @_;
+    my $fn;
+    if(($fn) = $name =~ /^DDG::\w+::(\w.+)$/o){
+        $fn =~ s/::/_/og;
+        $fn =~ s/([a-z])([A-Z])/$1_$2/og;
+        $fn = lc $fn;
+    }
+    return $fn;
+}
+
+1;

--- a/lib/DDG/Meta/Data.pm
+++ b/lib/DDG/Meta/Data.pm
@@ -1,4 +1,6 @@
 package DDG::Meta::Data;
+# ABSTRACT: Metadata functions for instant answers
+
 use Moo;
 use DDG::SpiceBundle::OpenSourceDuckDuckGo; 
 use DDG::GoodieBundle::OpenSourceDuckDuckGo; 
@@ -9,6 +11,8 @@ use Path::Class;
 use File::ShareDir 'dist_file';
 use IO::All;
 use Clone 'clone';
+
+use strict;
 
 sub debug { 0 }
 use if debug, 'Data::Printer';

--- a/lib/DDG/Meta/Data.pm
+++ b/lib/DDG/Meta/Data.pm
@@ -41,7 +41,7 @@ unless(%ia_metadata){
         my $file_data = decode_json(io($filename)->all);
 
         # check for decode_json_file error, returns undef
-        warn "reading metadata file failed ... $filename" unless $file_data;
+        die "reading metadata file failed ... $filename" unless $file_data;
 
         IA: while (my ($id, $module_data) = each %{ $file_data }) {
 
@@ -97,7 +97,7 @@ sub apply_keywords {
 
     my $ia;
     unless($ia = $self->get_ia(module => $target)){
-        warn "No metadata found for $target";
+        warn "No metadata found for $target" if debug;
         return;
     }
 

--- a/lib/DDG/Meta/Data.pm
+++ b/lib/DDG/Meta/Data.pm
@@ -48,7 +48,8 @@ unless(%ia_metadata){
 
         IA: while (my ($id, $module_data) = each %{ $file_data }) {
 
-            next unless $module_data->{status} eq 'live';
+            # 20150502 (zt) Can't filter like this yet as some tests depend on non-live IA metadata
+            #next unless $module_data->{status} eq 'live';
 
             # check for bad metadata.  We need a perl_module for the by_module key
             if($module_data->{perl_module} !~ /DDG::.+::.+/){


### PR DESCRIPTION
Note: This needs to be coordinated with internal changes.

DDG::Meta::Data - Mostly provides methods to instant answers so that, when interrogated, they can return metadata about themselves.  However, also includes lookup methods for cases when no IA object is available.

Some changes to dist.ini to allow container builds in travis and automatic Perl deps.