### PR TITLE
Update dist.ini

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -7,7 +7,7 @@ copyright_year   = 2013
 [PromptIfStale]
 index_base_url = http://duckpan.org
 module = Dist::Zilla::Plugin::UploadToDuckPAN
-module = WWWW::DuckDuckGo
+module = WWW::DuckDuckGo
 
 [AutoPrereqs]
 

--- a/dist.ini
+++ b/dist.ini
@@ -5,8 +5,9 @@ copyright_holder = DuckDuckGo, Inc. L<https://duckduckgo.com/>
 copyright_year   = 2013
 
 [PromptIfStale]
-index = http://duckpan.org
+index_base_url = http://duckpan.org
 module = Dist::Zilla::Plugin::UploadToDuckPAN
+module = WWWW::DuckDuckGo
 
 [AutoPrereqs]
 


### PR DESCRIPTION
This should ensure that we install WWW::DuckDuckGo via duckpan.org and keep it up to date.

This is required to ensure that WWW::DuckDuckGo is installed via duckpan.org as it's no longer hosted on CPAN.

Alternatively we may be able to skip installing it as a dependency? It may be required though as we are extending it: https://github.com/duckduckgo/duckduckgo/blob/62721ca720ffc6581bb81313dac55e15a5ffe44f/lib/DDG/ZeroClickInfo.pm#L5

/cc @zachthompson 