### PR TITLE
Autoprereqs ignore DDG::* packages

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -9,6 +9,7 @@ index = http://duckpan.org
 module = Dist::Zilla::Plugin::UploadToDuckPAN
 
 [AutoPrereqs]
+skip = ^DDG::
 
 [GatherDir]
 [PruneCruft]


### PR DESCRIPTION
This prevents marking the `DDG::(Goodie|Spice|Fathead|Longtail)Bundle::OpenSourceDuckDuckGo` bundles as dependencies.

/cc @zachthompson 