### PR TITLE
Allow conditional loading of IA bundles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
 install:
   - cpanm --quiet --notest Dist::Zilla
   - >
-      cpanm --mirror http://duckpan.org
+      cpanm --quiet --notest --mirror http://www.cpan.org/ --mirror http://duckpan.org
       DDG::GoodieBundle::OpenSourceDuckDuckGo
       DDG::SpiceBundle::OpenSourceDuckDuckGo
       DDG::FatheadBundle::OpenSourceDuckDuckGo

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,11 @@ before_install:
   - git config --global user.email $HOSTNAME":not-for-mail@travis-ci.org"
 install:
   - cpanm --quiet --notest Dist::Zilla
+  - >
+      cpanm --mirror http://duckpan.org
+      DDG::GoodieBundle::OpenSourceDuckDuckGo
+      DDG::SpiceBundle::OpenSourceDuckDuckGo
+      DDG::FatheadBundle::OpenSourceDuckDuckGoDDG::LongtailBundle::OpenSourceDuckDuckGo
   - dzil authordeps | grep -ve '^\W' | xargs -n 5 -P 10 cpanm --quiet --notest
   - dzil listdeps | grep -ve '^\W' | cpanm --quiet --notest --mirror http://www.cpan.org/ --mirror http://duckpan.org
 language: perl

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,8 @@ install:
       cpanm --mirror http://duckpan.org
       DDG::GoodieBundle::OpenSourceDuckDuckGo
       DDG::SpiceBundle::OpenSourceDuckDuckGo
-      DDG::FatheadBundle::OpenSourceDuckDuckGoDDG::LongtailBundle::OpenSourceDuckDuckGo
+      DDG::FatheadBundle::OpenSourceDuckDuckGo
+      DDG::LongtailBundle::OpenSourceDuckDuckGo
   - dzil authordeps | grep -ve '^\W' | xargs -n 5 -P 10 cpanm --quiet --notest
   - dzil listdeps | grep -ve '^\W' | cpanm --quiet --notest --mirror http://www.cpan.org/ --mirror http://duckpan.org
 language: perl

--- a/lib/DDG/Meta/Data.pm
+++ b/lib/DDG/Meta/Data.pm
@@ -40,7 +40,7 @@ unless(%ia_metadata){
         warn("No instant answer bundles installed. If you are developing an instant answer, please\n",
             "install one or more of the following (via `duckpan` or `cpanm --mirror http://duckpan.org`),\n",
 			"including the type with which you are working:\n\n\t",
-            join("\n\t", map{ "DDG::${_}Bundle::OpenSourceDuckDuckGo" } @ia_types), "\n");# and exit 1;
+            join("\n\t", map{ "DDG::${_}Bundle::OpenSourceDuckDuckGo" } @ia_types), "\n");
     }
 
     FILE: while (my ($type, $filename) = each %metadata_files) {

--- a/lib/DDG/Meta/Data.pm
+++ b/lib/DDG/Meta/Data.pm
@@ -9,7 +9,7 @@ use Clone 'clone';
 
 use strict;
 
-sub debug { 0 }
+sub debug { 1 }
 use if debug, 'Data::Printer';
 
 no warnings 'uninitialized';
@@ -26,17 +26,20 @@ unless(%ia_metadata){
 
     my @ia_types = qw(Spice Goodie Longtail Fathead);
 
-    # Load IA metadata files.
+    # Load IA metadata files. Not all types are required during development.
     my %metadata_files;
     for my $iat (@ia_types){
         my $bundle = "DDG::${iat}Bundle::OpenSourceDuckDuckGo";
-        eval "require $bundle" or next;
-        $metadata_files{$iat} = dist_file("DDG-${iat}Bundle-OpenSourceDuckDuckGo", lc $iat . '/meta/metadata.json');
+        eval "require $bundle";
+        my $f = eval{ dist_file("DDG-${iat}Bundle-OpenSourceDuckDuckGo", lc $iat . '/meta/metadata.json') }
+		    or (debug && warn $@);
+        $metadata_files{$iat} = $f if $f;
     }
 
     unless(%metadata_files){
-        warn("No instant answer bundles installed. If you are developing an instant answer,\n",
-            "please install one of the following (via `cpanm --mirror http://duckpan.org`):\n\n\t",
+        warn("No instant answer bundles installed. If you are developing an instant answer, please\n",
+            "install one or more of the following (via `duckpan` or `cpanm --mirror http://duckpan.org`),\n",
+			"including the type with which you are working:\n\n\t",
             join("\n\t", map{ "DDG::${_}Bundle::OpenSourceDuckDuckGo" } @ia_types), "\n") and exit 1;
     }
 

--- a/lib/DDG/Meta/Data.pm
+++ b/lib/DDG/Meta/Data.pm
@@ -52,8 +52,8 @@ unless(%ia_metadata){
             #next unless $module_data->{status} eq 'live';
 
             # check for bad metadata.  We need a perl_module for the by_module key
-            if($module_data->{perl_module} !~ /DDG::.+::.+/ and $module_data->{status} eq 'live'){
-                warn "Invalid perl_module for IA $id: $module_data->{perl_module} in $filename...skipping";
+            if($module_data->{perl_module} !~ /DDG::.+::.+/){
+                warn "Invalid perl_module for IA $id: $module_data->{perl_module} in $filename...skipping" if $module_data->{status} eq 'live';
                 next IA;
             }
 

--- a/lib/DDG/Meta/Data.pm
+++ b/lib/DDG/Meta/Data.pm
@@ -1,10 +1,6 @@
 package DDG::Meta::Data;
 # ABSTRACT: Metadata functions for instant answers
 
-use DDG::SpiceBundle::OpenSourceDuckDuckGo; 
-use DDG::GoodieBundle::OpenSourceDuckDuckGo; 
-use DDG::LongtailBundle::OpenSourceDuckDuckGo; 
-use DDG::FatheadBundle::OpenSourceDuckDuckGo; 
 use JSON::XS 'decode_json';
 use Path::Class;
 use File::ShareDir 'dist_file';
@@ -25,12 +21,21 @@ no warnings 'uninitialized';
 # }
 my %ia_metadata;
 
-my @ia_types = qw(Spice Goodie Longtail Fathead);
-
-my %metadata_files = map { $_ => dist_file("DDG-${_}Bundle-OpenSourceDuckDuckGo", lc $_ . '/meta/metadata.json') } @ia_types;
-
 # Only build metadata once. Not in BUILD so we can call apply_keywords directly
 unless(%ia_metadata){
+
+    my @ia_types = qw(Spice Goodie Longtail Fathead);
+
+    my %metadata_files;
+    for my $iat (@ia_types){
+        my $bundle = "DDG::${iat}Bundle::OpenSourceDuckDuckGo";
+        eval{ require $bundle } or next;
+        $metadata_files{$iat} = dist_file("DDG-${iat}Bundle-OpenSourceDuckDuckGo", lc $iat . '/meta/metadata.json';
+    }
+
+    die "No instant answer bundles installed. If you are developing an instant answer,\n",
+        "please install one of the following (via `cpanm --mirror http://duckpan.org`):\n\n\t",
+        join("\n\t", map{ "DDG::${_}Bundle::OpenSourceDuckDuckGo" } @ia_types), "\n";
 
     FILE: while (my ($type, $filename) = each %metadata_files) {
         warn "Processing IA type: $type with file $filename" if debug;

--- a/lib/DDG/Meta/Data.pm
+++ b/lib/DDG/Meta/Data.pm
@@ -26,16 +26,19 @@ unless(%ia_metadata){
 
     my @ia_types = qw(Spice Goodie Longtail Fathead);
 
+    # Load IA metadata files.
     my %metadata_files;
     for my $iat (@ia_types){
         my $bundle = "DDG::${iat}Bundle::OpenSourceDuckDuckGo";
-        eval{ require $bundle } or next;
-        $metadata_files{$iat} = dist_file("DDG-${iat}Bundle-OpenSourceDuckDuckGo", lc $iat . '/meta/metadata.json';
+        eval "require $bundle" or next;
+        $metadata_files{$iat} = dist_file("DDG-${iat}Bundle-OpenSourceDuckDuckGo", lc $iat . '/meta/metadata.json');
     }
 
-    die "No instant answer bundles installed. If you are developing an instant answer,\n",
-        "please install one of the following (via `cpanm --mirror http://duckpan.org`):\n\n\t",
-        join("\n\t", map{ "DDG::${_}Bundle::OpenSourceDuckDuckGo" } @ia_types), "\n";
+    unless(%metadata_files){
+        warn("No instant answer bundles installed. If you are developing an instant answer,\n",
+            "please install one of the following (via `cpanm --mirror http://duckpan.org`):\n\n\t",
+            join("\n\t", map{ "DDG::${_}Bundle::OpenSourceDuckDuckGo" } @ia_types), "\n") and exit 1;
+    }
 
     FILE: while (my ($type, $filename) = each %metadata_files) {
         warn "Processing IA type: $type with file $filename" if debug;

--- a/lib/DDG/Meta/Data.pm
+++ b/lib/DDG/Meta/Data.pm
@@ -9,7 +9,7 @@ use Clone 'clone';
 
 use strict;
 
-sub debug { 1 }
+sub debug { 0 }
 use if debug, 'Data::Printer';
 
 no warnings 'uninitialized';

--- a/lib/DDG/Meta/Data.pm
+++ b/lib/DDG/Meta/Data.pm
@@ -40,7 +40,7 @@ unless(%ia_metadata){
         warn("No instant answer bundles installed. If you are developing an instant answer, please\n",
             "install one or more of the following (via `duckpan` or `cpanm --mirror http://duckpan.org`),\n",
 			"including the type with which you are working:\n\n\t",
-            join("\n\t", map{ "DDG::${_}Bundle::OpenSourceDuckDuckGo" } @ia_types), "\n") and exit 1;
+            join("\n\t", map{ "DDG::${_}Bundle::OpenSourceDuckDuckGo" } @ia_types), "\n");# and exit 1;
     }
 
     FILE: while (my ($type, $filename) = each %metadata_files) {


### PR DESCRIPTION
When developing it isn't necessary to have all IA types, e.g. goodie, spice, fathead, and longtail, loaded but only the type being worked on.  This change allows our bundles and their metadata to be conditionally loaded and used in DDG::Meta::Data.

Should help fix [issue #258](https://github.com/duckduckgo/p5-app-duckpan/issues/258), although at least one bundle is still required to be installed.