### PR TITLE
escape chars in metadata

### DIFF
--- a/lib/DDG/Meta/Data.pm
+++ b/lib/DDG/Meta/Data.pm
@@ -164,7 +164,7 @@ sub get_ia {
 sub get_js {
     my ($self, $id) = @_;
 
-    my $metaj = eval { encode_json($self->get_ia(id => $id)) } || qq|{"encode_json error":"$@"}|;
+    my $metaj = eval { JSON::XS->new->ascii->encode($self->get_ia(id => $id)) } || qq|{"encode_json error":"$@"}|;
     return qq(DDH.$id=DDH.$id||{};DDH.$id.meta=$metaj;); 
 }
 


### PR DESCRIPTION
![selection_036](https://cloud.githubusercontent.com/assets/1882892/7801916/a0f492da-02fa-11e5-8e16-acbef31f1480.png)

Fixes other encoding in the metadata too. 
Before:
![selection_037](https://cloud.githubusercontent.com/assets/1882892/7801919/ade8855a-02fa-11e5-911d-f6cb496c4619.png)

After:
![selection_038](https://cloud.githubusercontent.com/assets/1882892/7801923/b265f2b6-02fa-11e5-9403-5611e5dd8b93.png)


@russellholt @zachthompson 
