### PR TITLE
Remove apply_keywords from DDG::Meta::Data

### DIFF
--- a/lib/DDG/Meta.pm
+++ b/lib/DDG/Meta.pm
@@ -16,7 +16,6 @@ use DDG::Meta::Information;
 use DDG::Meta::Helper;
 use DDG::Meta::AnyBlock;
 use DDG::Meta::CountryCodes;
-use DDG::Meta::Data;
 
 use MooX ();
 
@@ -73,7 +72,6 @@ sub apply_goodie_keywords {
 	DDG::Meta::ShareDir->apply_keywords($target);
 	DDG::Meta::Block->apply_keywords($target);
 	DDG::Meta::Information->apply_keywords($target);
-	DDG::Meta::Data->apply_keywords($target);
 	DDG::Meta::Helper->apply_keywords($target);
 	DDG::Meta::RequestHandler->apply_keywords($target,sub {
 		shift->zci_new(
@@ -103,7 +101,6 @@ sub apply_spice_keywords {
 	DDG::Meta::ShareDir->apply_keywords($target);
 	DDG::Meta::Block->apply_keywords($target);
 	DDG::Meta::Information->apply_keywords($target);
-	DDG::Meta::Data->apply_keywords($target);
 	DDG::Meta::Helper->apply_keywords($target);
 	DDG::Meta::RequestHandler->apply_keywords($target,sub {
 		shift->spice_new(@_);
@@ -120,7 +117,6 @@ sub apply_fathead_keywords {
     DDG::Meta::ShareDir->apply_keywords($target);
     DDG::Meta::Fathead->apply_keywords($target);
     DDG::Meta::Information->apply_keywords($target);    
-    DDG::Meta::Data->apply_keywords($target);
     DDG::Meta::AnyBlock->apply_keywords($target);
     Moo::Role->apply_role_to_package($target, "DDG::IsFathead");
 }
@@ -134,7 +130,6 @@ sub apply_longtail_keywords {
     DDG::Meta::ZeroClickInfo->apply_keywords($target);
     DDG::Meta::ShareDir->apply_keywords($target);
     DDG::Meta::Information->apply_keywords($target);
-    DDG::Meta::Data->apply_keywords($target);
     DDG::Meta::AnyBlock->apply_keywords($target);
     Moo::Role->apply_role_to_package($target, "DDG::IsLongtail");
 }


### PR DESCRIPTION
NOTE: Needs to be coordinated with internal.

Abandon adding metadata methods to IAs directly.  We seemingly can't get away from needing to look up metadata after the fact, e.g. via get_ia, and this will simplify the api.  It will also allow us to dynamically update metadata in the future without re-applying keywords.