### PR TITLE
Escape left braces in regexes to fix warnings

### DIFF
--- a/lib/DDG/Meta/Information.pm
+++ b/lib/DDG/Meta/Information.pm
@@ -313,10 +313,10 @@ This function returns the plugin's attribution information in a hash
 			my $value = shift @{$_};
 			my ( $a, $b ) = ref $value eq 'ARRAY' ? ( $value->[0], $value->[1] ) : ( $value, $value );
 			my ( $link, $val ) = @{$supported_types{$type}};
-			$link =~ s/{{a}}/$a/;
-			$link =~ s/{{b}}/$b/;
-			$val =~ s/{{a}}/$a/;
-			$val =~ s/{{b}}/$b/;
+			$link =~ s/\Q{{a}}/$a/;
+			$link =~ s/\Q{{b}}/$b/;
+			$val =~ s/\Q{{a}}/$a/;
+			$val =~ s/\Q{{b}}/$b/;
 			push @attribution_links, $link, $val;
 		}
 		return \@attribution_links;

--- a/lib/DDG/Rewrite.pm
+++ b/lib/DDG/Rewrite.pm
@@ -9,17 +9,17 @@ sub BUILD {
 	my ( $self ) = @_;
 	my $to = $self->to;
 	my $callback = $self->has_callback ? $self->callback : "";
-	croak "Missing callback attribute for {{callback}} in to" if ($to =~ s/{{callback}}/$callback/g && !$self->has_callback);
+	croak "Missing callback attribute for {{callback}} in to" if ($to =~ s/\Q{{callback}}/$callback/g && !$self->has_callback);
 	# Make sure we replace "{{dollar}}"" with "{dollar}".
-	$to =~ s/{{dollar}}/\$\{dollar\}/g;
+	$to =~ s/\Q{{dollar}}/\$\{dollar\}/g;
 	my @missing_envs;
-	for ($to =~ m/{{ENV{(\w+)}}}/g) {
+	for ($to =~ m/\Q{{ENV{\E(\w+)}}}/g) {
 		if (defined $ENV{$_}) {
 			my $val = $ENV{$_};
-			$to =~ s/{{ENV{$_}}}/$val/g;
+			$to =~ s/\Q{{ENV{$_}}}/$val/g;
 		} else {
 			push @missing_envs, $_;
-			$to =~ s/{{ENV{$_}}}//g;
+			$to =~ s/\Q{{ENV{$_}}}//g;
 		}
 	}
 	$self->_missing_envs(\@missing_envs) if @missing_envs;


### PR DESCRIPTION
perl 5.22 throws a warning 'Unescaped left brace in regex is deprecated' if
braces are not escaped in regexes.