### PR TITLE
Support alt_to attribute in spices

### DIFF
--- a/lib/DDG/Meta/ZeroClickInfoSpice.pm
+++ b/lib/DDG/Meta/ZeroClickInfoSpice.pm
@@ -167,6 +167,7 @@ sub apply_keywords {
 		if(my $alt_to = $zcispice_params{alt_to}){
 			my ($base_target) = $target =~ /^(.+::)\w+$/;
 			while(my ($to, $params) = each %$alt_to){
+				check_zeroclickinfospice_key($_) for keys %$params;
 				my $target = "$base_target$to";
 				my ($callback, $path) = @{params_from_target($target)};
 				$rewrites{$to} = create_rewrite($callback, $path, $params);

--- a/lib/DDG/Meta/ZeroClickInfoSpice.pm
+++ b/lib/DDG/Meta/ZeroClickInfoSpice.pm
@@ -170,7 +170,7 @@ sub apply_keywords {
 		if(my $alt_to = $zcispice_params{alt_to}){
 			my ($base_target) = $target =~ /^(.+::)\w+$/;
 			while(my ($to, $params) = each %$alt_to){
-				my $target = "${base_target}::$to";
+				my $target = "$base_target$to";
 				my ($callback, $path) = @{params_from_target($target)};
 				my $rewrite = create_rewrite($callback, $path, $params);
 				$conf .= $rewrite->nginx_conf;

--- a/lib/DDG/Test/Spice.pm
+++ b/lib/DDG/Test/Spice.pm
@@ -93,6 +93,44 @@ testing your L<DDG::Spice> alone or in combination with others.
 		}
 	},@_)});
 
+=keyword alt_to_test
+
+Use this function to verify your spice's alt_to definitions:
+
+	alt_to_test('DDG::Spice::My::Spice', [qw(alt1 alt2 alt3)]);
+
+This would check for the following:
+
+	callbacks 'ddg_spice_my_alt[123]'
+	paths '/js/spice/my/alt[123]/'
+
+=cut
+
+	$stash->add_symbol('&alt_to_test', sub {
+		my ($spice, $alt_tos) = @_;
+
+		require_ok($spice);
+		my $d = $spice->new(block => 1);
+
+		my $rewrites = $d->alt_rewrites;
+		ok($rewrites, "$spice has rewrites");
+
+		my ($base) =~ $spice =~ /^DDG::(.+)::/;
+		ok($base, "Extract base from $spice");
+
+		$base = lc $base;
+		my $cb_base = $base;
+		$cb_base =~ s/::/_/g;
+		my $path_base = $base;
+		$path_base =~ s|::|/|g;
+
+		for my $alt (@$alt_tos){
+			my $rw = $rewrites->{$alt};
+			ok($rw, "$alt exists");
+			ok($rw->callback eq "ddg_${cb_base}_$alt", "$alt callback");
+			ok($rw->path eq "/js/$cb_base/$alt/", "$alt path");
+		}
+	});
 }
 
 1;

--- a/lib/DDG/Test/Spice.pm
+++ b/lib/DDG/Test/Spice.pm
@@ -115,11 +115,10 @@ This would check for the following:
 		my $rewrites = $spice->alt_rewrites;
 		ok($rewrites, "$spice has rewrites");
 
-		ok($spice =~ /^DDG::(.+)::/, "Extract base from $spice");
-		my $base = $1;
+		ok($spice =~ /^(DDG.*?)::(.+)::/, "Extract base from $spice");
+		my ($ddg, $base) = map {lc} ($1, $2);
 
-		$base = lc $base;
-		my $cb_base = $base;
+		my $cb_base = "${ddg}_$base";
 		$cb_base =~ s/::/_/g;
 		my $path_base = $base;
 		$path_base =~ s|::|/|g;
@@ -127,7 +126,7 @@ This would check for the following:
 		for my $alt (@$alt_tos){
 			my $rw = $rewrites->{$alt};
 			ok($rw, "$alt exists");
-			ok($rw->callback eq "ddg_${cb_base}_$alt", "$alt callback");
+			ok($rw->callback eq "${cb_base}_$alt", "$alt callback");
 			ok($rw->path eq "/js/$path_base/$alt/", "$alt path");
 		}
 	});

--- a/lib/DDG/Test/Spice.pm
+++ b/lib/DDG/Test/Spice.pm
@@ -8,6 +8,7 @@ use Test::More;
 use DDG::Test::Block;
 use DDG::ZeroClickInfo::Spice;
 use Package::Stash;
+use Class::Load 'load_class';
 
 =head1 DESCRIPTION
 
@@ -109,14 +110,13 @@ This would check for the following:
 	$stash->add_symbol('&alt_to_test', sub {
 		my ($spice, $alt_tos) = @_;
 
-		require_ok($spice);
-		my $d = $spice->new(block => 1);
+		load_class($spice);
 
-		my $rewrites = $d->alt_rewrites;
+		my $rewrites = $spice->alt_rewrites;
 		ok($rewrites, "$spice has rewrites");
 
-		my ($base) =~ $spice =~ /^DDG::(.+)::/;
-		ok($base, "Extract base from $spice");
+		ok($spice =~ /^DDG::(.+)::/, "Extract base from $spice");
+		my $base = $1;
 
 		$base = lc $base;
 		my $cb_base = $base;
@@ -128,7 +128,7 @@ This would check for the following:
 			my $rw = $rewrites->{$alt};
 			ok($rw, "$alt exists");
 			ok($rw->callback eq "ddg_${cb_base}_$alt", "$alt callback");
-			ok($rw->path eq "/js/$cb_base/$alt/", "$alt path");
+			ok($rw->path eq "/js/$path_base/$alt/", "$alt path");
 		}
 	});
 }

--- a/lib/DDG/Test/Spice.pm
+++ b/lib/DDG/Test/Spice.pm
@@ -7,6 +7,7 @@ use Carp;
 use Test::More;
 use DDG::Test::Block;
 use DDG::ZeroClickInfo::Spice;
+use DDG::Meta::ZeroClickInfoSpice;
 use Package::Stash;
 use Class::Load 'load_class';
 
@@ -115,19 +116,15 @@ This would check for the following:
 		my $rewrites = $spice->alt_rewrites;
 		ok($rewrites, "$spice has rewrites");
 
-		ok($spice =~ /^(DDG.*?)::(.+)::/, "Extract base from $spice");
-		my ($ddg, $base) = map {lc} ($1, $2);
-
-		my $cb_base = "${ddg}_$base";
-		$cb_base =~ s/::/_/g;
-		my $path_base = $base;
-		$path_base =~ s|::|/|g;
+		ok($spice =~ /^(DDG.+::)/, "Extract base from $spice");
+		my $base = $1;
 
 		for my $alt (@$alt_tos){
+			my ($cb, $path) = @{DDG::Meta::ZeroClickInfoSpice::params_from_target("$base$alt")};
 			my $rw = $rewrites->{$alt};
 			ok($rw, "$alt exists");
-			ok($rw->callback eq "${cb_base}_$alt", "$alt callback");
-			ok($rw->path eq "/js/$path_base/$alt/", "$alt path");
+			ok($rw->callback eq $cb, "$alt callback");
+			ok($rw->path eq $path, "$alt path");
 		}
 	});
 }

--- a/t/50-spice.t
+++ b/t/50-spice.t
@@ -18,6 +18,7 @@ use DDGTest::Spice::Data;
 use DDGTest::Spice::Cached;
 use DDGTest::Spice::ChangeCached;
 use DDGTest::Spice::MultiTriggerType;
+use DDGTest::Spice::AltTo;
 
 use DDG::ZeroClickInfo::Spice;
 
@@ -67,6 +68,8 @@ my $zci_spice = DDG::ZeroClickInfo::Spice->new(
 isa_ok($zci_spice,'DDG::ZeroClickInfo::Spice');
 is($zci_spice->call,'/js/spice/some_thing/a%23%23a/b%20%20b/c%23%3F%3Fc','Checking for proper call path');
 
+alt_to_test('DDGTest::Spice::AltTo', [qw(alt1 alt2)]);
+
 ddg_spice_test(
 	# DDGTest::Spice::Flashtest
 	[qw(
@@ -75,6 +78,7 @@ ddg_spice_test(
 		DDGTest::Spice::Cached
 		DDGTest::Spice::ChangeCached
 		DDGTest::Spice::MultiTriggerType
+		DDGTest::Spice::AltTo
 	)],
 	'data test' => test_spice( 
 		'/js/spice/data/test',
@@ -127,6 +131,12 @@ ddg_spice_test(
 		'/js/spice/multi_trigger_type/multitrigger%20test',
 		call_type => 'include',
 		caller => 'DDGTest::Spice::MultiTriggerType',
+		is_cached => 1
+	),
+	'alt_to test' => test_spice(
+		'/js/spice/alt_to/test',
+		call_type => 'include',
+		caller => 'DDGTest::Spice::AltTo',
 		is_cached => 1
 	),
 	# 'flash version' => test_spice( 

--- a/t/lib/DDGTest/Spice/AltTo.pm
+++ b/t/lib/DDGTest/Spice/AltTo.pm
@@ -1,0 +1,16 @@
+package DDGTest::Spice::AltTo;
+
+use DDG::Spice;
+
+triggers start => 'alt_to';
+
+spice to => 'https://duckduckgo.com/alt_to.js?q=$1&callback={{callback}}';
+
+spice alt_to => {
+	alt1 => { to => 'https://duckduckgo.com/alt1.js?q=$1&callback={{callback}}' },
+	alt2 => { to => 'https://duckduckgo.com/alt2.js?q=$1&callback={{callback}}' }
+};
+
+handle remainder => sub { return $_ };
+
+1;


### PR DESCRIPTION
Currently we need placeholder modules to support alternate end points in spices, e.g. [Dictionary::Pronunciation](https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/Spice/Dictionary/Pronunciation.pm) and friends.  This change allows spices to specify an `alt_to` attribute containing any of the [spice attributes](https://github.com/duckduckgo/duckduckgo/blob/80d6b9469f1ea736df8cff6fc01f87df0b3599e0/lib/DDG/Meta/ZeroClickInfoSpice.pm#L15-L28).  The `alt_to` values are used to:

1.  Generate nginx entries as they did in the past.
2. Are accessible via alt_rewrites for other code, e.g. [duckpan](https://github.com/duckduckgo/p5-app-duckpan/blob/master/lib/App/DuckPAN/Web.pm#L62), that needs to dynamically generate these end points.

There are several dependent and/or related PRs:
* [Support alt_to in duckpan](https://github.com/duckduckgo/p5-app-duckpan/pull/283)
* [Update spice repo](https://github.com/duckduckgo/zeroclickinfo-spice/pull/2308)
* #5357 (internal)

cc @moollaza @russellholt 