### PR TITLE
get_nginx_conf depends on alt_rewrites

### DIFF
--- a/lib/DDG/Meta/ZeroClickInfoSpice.pm
+++ b/lib/DDG/Meta/ZeroClickInfoSpice.pm
@@ -180,8 +180,11 @@ sub apply_keywords {
 	$stash->add_symbol('&get_nginx_conf',sub {
 		my $nginx_conf_func = $stash->get_symbol('&nginx_conf');
 		return $nginx_conf_func->(@_) if $nginx_conf_func;
-		return '' unless $target->has_rewrite;
-		my $conf = $target->rewrite->nginx_conf;
+
+		my $conf = ''; # (20151208 zt) just in case can't handle undef ;-/
+		if($target->has_rewrite){
+			$conf = $target->rewrite->nginx_conf;
+		}
 
 		# check if we have alternate end points to add
 		for my $r (values %{$target->alt_rewrites}){

--- a/lib/DDG/Meta/ZeroClickInfoSpice.pm
+++ b/lib/DDG/Meta/ZeroClickInfoSpice.pm
@@ -180,8 +180,9 @@ sub apply_keywords {
 	$stash->add_symbol('&get_nginx_conf',sub {
 		my $nginx_conf_func = $stash->get_symbol('&nginx_conf');
 		return $nginx_conf_func->(@_) if $nginx_conf_func;
-
-		my $conf = ''; # (20151208 zt) just in case can't handle undef ;-/
+ 
+		# (20151208 zt) just in case downstream can't handle undef ;-/
+		my $conf = '';
 		if($target->has_rewrite){
 			$conf = $target->rewrite->nginx_conf;
 		}


### PR DESCRIPTION
Continue to evaluate alt_rewrites in get_nginx_conf even if has_rewrite is false.  The [sound cloud](https://github.com/duckduckgo/zeroclickinfo-spice/blob/zach/alt-to/lib/DDG/Spice/SoundCloud.pm#L21) IA is missing a 'spice to' in the parent IA causing the alt_to links to be skipped.

@b2ddg I'll let @moollaza handle this since he's got it all fresh in his head.