### PR TITLE
Use bracket syntax to allow for numerical ids

### DIFF
--- a/lib/DDG/Meta/Data.pm
+++ b/lib/DDG/Meta/Data.pm
@@ -139,7 +139,7 @@ sub get_js {
 
     my $id = $ia->{id};
     my $metaj = eval { JSON::XS->new->ascii->encode($ia) } || return;
-    return qq(DDH.$id=DDH.$id||{};DDH.$id.meta=$metaj;); 
+    return qq(DDH[\"$id\"]=DDH[\"$id\"]||{};DDH[\"$id\"].meta=$metaj;); 
 }
 
 # return a hash of IA objects by id


### PR DESCRIPTION
We have a couple cheat sheets, `8086_cheat_sheet` and `8085_cheat_sheet`
which are being reference using dot notation, causing errors as `DDH.8086_cheat_sheet` is not valid.

E.g. https://duckduckgo.com/?q=8086+symbols

This ensures we reference DDH properties correctly.

/cc @zachthompson @russellholt