### PR TITLE
Encode query for spice call

### DIFF
--- a/lib/DDG/Meta/ZeroClickInfoSpice.pm
+++ b/lib/DDG/Meta/ZeroClickInfoSpice.pm
@@ -87,7 +87,7 @@ sub apply_keywords {
 			} elsif (!defined $_) {
 				# do nothing
 			} else {
-				push @call, uri_encode($_);
+				push @call, $_;
 			}
 		}
 		$params{'call_data'} = $data->data if $data;
@@ -95,7 +95,7 @@ sub apply_keywords {
 			if ($params{'call_type'} eq 'include') {
 				$params{'call'} = $target->path.join('/',map { uri_encode($_,1) } @call);
 			} elsif (scalar @call == 1) {
-				$params{'call'} = $call[0];
+				$params{'call'} = uri_encode($call[0]);
 			} else {
 				croak "DDG::ZeroClickInfo::Spice can't handle more then one value in return list on non include call_type";
 			}

--- a/lib/DDG/Meta/ZeroClickInfoSpice.pm
+++ b/lib/DDG/Meta/ZeroClickInfoSpice.pm
@@ -87,7 +87,7 @@ sub apply_keywords {
 			} elsif (!defined $_) {
 				# do nothing
 			} else {
-				push @call, $_;
+				push @call, uri_encode($_);
 			}
 		}
 		$params{'call_data'} = $data->data if $data;

--- a/t/50-spice.t
+++ b/t/50-spice.t
@@ -79,6 +79,7 @@ ddg_spice_test(
 		DDGTest::Spice::ChangeCached
 		DDGTest::Spice::MultiTriggerType
 		DDGTest::Spice::AltTo
+		DDGTest::Spice::CallTypeSelf
 	)],
 	'data test' => test_spice( 
 		'/js/spice/data/test',
@@ -137,6 +138,12 @@ ddg_spice_test(
 		'/js/spice/alt_to/test',
 		call_type => 'include',
 		caller => 'DDGTest::Spice::AltTo',
+		is_cached => 1
+	),
+	'call type self "999"' => test_spice(
+		'%22999%22',
+		call_type => 'self',
+		caller => 'DDGTest::Spice::CallTypeSelf',
 		is_cached => 1
 	),
 	# 'flash version' => test_spice( 

--- a/t/lib/DDGTest/Spice/CallTypeSelf.pm
+++ b/t/lib/DDGTest/Spice/CallTypeSelf.pm
@@ -1,0 +1,15 @@
+package DDGTest::Spice::CallTypeSelf;
+
+use strict;
+use DDG::Spice;
+
+spice call_type => 'self';
+
+triggers start => 'call type self';
+
+handle remainder => sub {
+	return $_ if $_;
+	return;
+};
+
+1;


### PR DESCRIPTION
Encode a query before making a request. Affects spices without the 'spice to' parameter.

- [ ]  which spices are affected by this? any besides sound_cloug?

Fixes: https://github.com/duckduckgo/duckduckgo/issues/167

@moollaza @bsstoner @zachthompson 