### PR TITLE
Fix stale documentation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ If you're reporting an issue with an Instant Answer, please add the issue to an 
 General DuckDuckGo issues (not related to our open source projects) should be reported here: https://duckduckgo.com/feedback 
 
 
-If you are interested in creating a DuckDuckGo Instant Answer please refer to our documentation: https://duck.co/duckduckhack/ddh-intro
+If you are interested in creating a DuckDuckGo Instant Answer please refer to our documentation: http://docs.duckduckhack.com/


### PR DESCRIPTION
The link to documentation should point to the new version of documentation