### PR TITLE
Add proxy_ssl_server_name to ssl upstreams.

### DIFF
--- a/lib/DDG/Rewrite.pm
+++ b/lib/DDG/Rewrite.pm
@@ -175,6 +175,7 @@ sub _build_nginx_conf {
 	$cfg .= "\trewrite ^".$self->path.($self->has_from ? $self->from : "(.*)")." ".$uri_path." break;\n";
 	$cfg .= "\tproxy_pass $upstream;\n";
 	$cfg .= "\tproxy_set_header ".$self->proxy_x_forwarded_for.";\n" if $is_duckduckgo;
+	$cfg .= "\tproxy_ssl_server_name on;\n" if $scheme =~ /https/;
 
 	if($self->has_proxy_cache_valid) {
 		# This tells Nginx how long the response should be kept.

--- a/t/55-rewrite.t
+++ b/t/55-rewrite.t
@@ -102,6 +102,7 @@ is($minrewrite_https->nginx_conf,'location ^~ /js/spice/spice_name/ {
 	set $spice_name_upstream https://some.api:443;
 	rewrite ^/js/spice/spice_name/(.*) /$1 break;
 	proxy_pass $spice_name_upstream;
+	proxy_ssl_server_name on;
 	expires 1s;
 }
 ','Checking generated nginx.conf');


### PR DESCRIPTION
This change enables SNI for ssl upstreams.  For more info on SNI see:
https://en.wikipedia.org/wiki/Server_Name_Indication

This fixes problems we had with a couple of upstreams such as isitup.org.  Note that I added SNI for all ssl upstreams.  I don't believe this will cause issues for any of the other ssl upstreams.  It works with the github upstream.  

# testing
  - [x] isitup.org upstream
  - [x] github ssl upstream

There are 66 ssl upstreams.  I haven't tested them all.  I guess we don't have a way to do that really.  Other than manually.