### PR TITLE
Allow empty triggers

### DIFF
--- a/lib/DDG/Meta/Block.pm
+++ b/lib/DDG/Meta/Block.pm
@@ -56,7 +56,9 @@ Gives back if the plugin has triggers at all
 
 =cut
 
-	$stash->add_symbol('&has_triggers',sub { $triggers ? 1 : 0 });
+	$stash->add_symbol('&has_triggers',sub {
+			defined($triggers) && $triggers->has_triggers;
+	});
 
 =keyword triggers
 


### PR DESCRIPTION
Lets triggers be specified that don't have any values, as long as at least some defined triggers are used.

See [the Cheat Sheets PR](https://github.com/duckduckgo/zeroclickinfo-goodies/pull/2170) in which triggers are dynamically generated - it is very possible for some trigger types to have no triggers associated with them, but still be declared. In this case the functionality is useful.

At least one set of triggers is required to be defined however, and having no triggers defined will result in the same error as if no triggers were declared.