### PR TITLE
Allow caching of metadata

### DIFF
--- a/lib/DDG/Meta/Data.pm
+++ b/lib/DDG/Meta/Data.pm
@@ -43,6 +43,8 @@ unless(%ia_metadata){
 			unless($res->is_success || $res->code == 304){
 					debug && warn "Failed to download metadata: " . $res->status_line;
 			}
+		} else {
+			debug && warn "Not fetching new metadata, cache timeout not yet expired";
 		}
 
     # Decompress to command-line

--- a/lib/DDG/Meta/Data.pm
+++ b/lib/DDG/Meta/Data.pm
@@ -34,15 +34,16 @@ unless(%ia_metadata){
     debug && warn "Processing metadata";
 
     my $f = "$mdir/metadata.json.bz2";
-    unless($ENV{NO_METADATA_DOWNLOAD}){
-        my $ua = LWP::UserAgent->new;
-        $ua->timeout(5);
-        $ua->default_header('Accept-Encoding' => scalar HTTP::Message::decodable());
-        my $res = $ua->mirror('http://ddg-community.s3.amazonaws.com/metadata/repo_all.json.bz2', $f);
-        unless($res->is_success || $res->code == 304){
-            debug && warn "Failed to download metdata: " . $res->status_line;
-        }
-    }
+    my $timeout = $ENV{DDG_METADATA_TIMEOUT} || 0;
+		if (not -e $f or -M $f > $timeout) {
+			my $ua = LWP::UserAgent->new;
+			$ua->timeout(5);
+			$ua->default_header('Accept-Encoding' => scalar HTTP::Message::decodable());
+			my $res = $ua->mirror('http://ddg-community.s3.amazonaws.com/metadata/repo_all.json.bz2', $f);
+			unless($res->is_success || $res->code == 304){
+					debug && warn "Failed to download metadata: " . $res->status_line;
+			}
+		}
 
     # Decompress to command-line
     open my $fh, "bzip2 -dc $f |" or die "Failed to open file $f: $!";

--- a/lib/DDG/Meta/Data.pm
+++ b/lib/DDG/Meta/Data.pm
@@ -24,116 +24,116 @@ my %ia_metadata;
 # Only build metadata once.
 unless(%ia_metadata){
 
-    my $tmpdir = $ENV{METADATA_TMP_DIR} || '/var/tmp/ddg-metadata';
+	my $tmpdir = $ENV{METADATA_TMP_DIR} || '/var/tmp/ddg-metadata';
 
-    my $mdir = "$tmpdir-$>";
-    unless(-d $mdir){
-        pathmk $mdir or die "Failed to mkdir $mdir: $!";
-    }
+	my $mdir = "$tmpdir-$>";
+	unless(-d $mdir){
+		pathmk $mdir or die "Failed to mkdir $mdir: $!";
+	}
 
-    debug && warn "Processing metadata";
+	debug && warn "Processing metadata";
 
-    my $f = "$mdir/metadata.json.bz2";
-    my $timeout = $ENV{DDG_METADATA_TIMEOUT} || 0;
-		if (not -e $f or -M $f > $timeout) {
-			my $ua = LWP::UserAgent->new;
-			$ua->timeout(5);
-			$ua->default_header('Accept-Encoding' => scalar HTTP::Message::decodable());
-			my $res = $ua->mirror('http://ddg-community.s3.amazonaws.com/metadata/repo_all.json.bz2', $f);
-			unless($res->is_success || $res->code == 304){
-					debug && warn "Failed to download metadata: " . $res->status_line;
-			}
-		} else {
-			debug && warn "Not fetching new metadata, cache timeout not yet expired";
+	my $f = "$mdir/metadata.json.bz2";
+	my $timeout = $ENV{DDG_METADATA_TIMEOUT} || 0;
+	if (not -e $f or -M $f > $timeout) {
+		my $ua = LWP::UserAgent->new;
+		$ua->timeout(5);
+		$ua->default_header('Accept-Encoding' => scalar HTTP::Message::decodable());
+		my $res = $ua->mirror('http://ddg-community.s3.amazonaws.com/metadata/repo_all.json.bz2', $f);
+		unless($res->is_success || $res->code == 304){
+			debug && warn "Failed to download metadata: " . $res->status_line;
+		}
+	} else {
+		debug && warn "Not fetching new metadata, cache timeout not yet expired";
+	}
+
+	# Decompress to command-line
+	open my $fh, "bzip2 -dc $f |" or die "Failed to open file $f: $!";
+	# slurp into a single string
+	my $json = do { local $/;  <$fh> };
+	close $fh;
+	my $metadata = decode_json($json);
+
+	# { "<id>": {
+	#     "id": " "
+	#     "signal" : " "
+	#     ....
+	# }
+
+	IA: while (my ($id, $ia) = each %{ $metadata }) {
+
+		# 20150502 (zt) Can't filter like this yet as some tests depend on non-live IA metadata
+		#next unless $ia->{status} eq 'live';
+
+		# check for bad metadata.  We need a perl_module for the by_module key
+		if($ia->{perl_module} !~ /DDG::.+::.+/){
+			warn "Invalid perl_module for IA $id: $ia->{perl_module} in metadata...skipping" if $ia->{status} eq 'live';
+			next IA;
 		}
 
-    # Decompress to command-line
-    open my $fh, "bzip2 -dc $f |" or die "Failed to open file $f: $!";
-    # slurp into a single string
-    my $json = do { local $/;  <$fh> };
-    close $fh;
-    my $metadata = decode_json($json);
+		# warn if we run into a duplicate id.  These should be unique within *and*
+		# across all IA types
+		if( $ia_metadata{id}{$id} ){
+			warn "Duplicate ID for IA with ID: $id";
+		}
 
-    # { "<id>": {
-    #     "id": " "
-    #     "signal" : " "
-    #     ....
-    # }
+		my $perl_module = $ia->{perl_module};
 
-    IA: while (my ($id, $ia) = each %{ $metadata }) {
+		# Clean up/set some values
+		$ia->{signal_from} ||= $ia->{id};
+		$ia->{js_callback_name} = _js_callback_name($perl_module);
 
-        # 20150502 (zt) Can't filter like this yet as some tests depend on non-live IA metadata
-        #next unless $ia->{status} eq 'live';
+		#add new ia to ia_metadata{id}
+		$ia_metadata{id}{$id} = $ia;
+		#add new ia to ia_metadata{module}. Multiple ias per module possible
+		push @{$ia_metadata{module}{$perl_module}}, $ia;
+		# by language for multilang wiki
+		if($ia->{repo} eq 'fathead'){
+			my $source = $ia->{src_id};
+			# by source number for fatheads
+			$ia_metadata{fathead_source}{$source} = $ia;
+			# by language for multi language wiki sources
+			# check that language is set since most fatheads don't have a language
+			if( my $lang = $ia->{src_options}{language}){
+				# By default use current source
+				my $want_src = $source;
+				if(exists $ia_metadata{fathead_lang}{$lang}){
+					my $prev_ia = $ia_metadata{fathead_source}{$ia_metadata{fathead_lang}{$lang}};
+					# Skip setting lang to source if existing src_id is lower
+					$want_src = 0 if $prev_ia->{src_id} < $ia->{src_id};
+				}
+				$ia_metadata{fathead_lang}{$lang} = $want_src if $want_src;
+			}
+			my $min_length = $ia->{src_options}{min_abstract_length};
+			$ia_metadata{fathead_min_length}{$source} = $min_length if $min_length;
+		}
+	}
 
-        # check for bad metadata.  We need a perl_module for the by_module key
-        if($ia->{perl_module} !~ /DDG::.+::.+/){
-            warn "Invalid perl_module for IA $id: $ia->{perl_module} in metadata...skipping" if $ia->{status} eq 'live';
-            next IA;
-        }
-
-        # warn if we run into a duplicate id.  These should be unique within *and*
-        # across all IA types
-        if( $ia_metadata{id}{$id} ){
-            warn "Duplicate ID for IA with ID: $id";
-        }
-
-        my $perl_module = $ia->{perl_module};
-
-        # Clean up/set some values
-        $ia->{signal_from} ||= $ia->{id};
-        $ia->{js_callback_name} = _js_callback_name($perl_module);
-
-        #add new ia to ia_metadata{id}
-        $ia_metadata{id}{$id} = $ia;
-        #add new ia to ia_metadata{module}. Multiple ias per module possible
-        push @{$ia_metadata{module}{$perl_module}}, $ia;
-        # by language for multilang wiki
-        if($ia->{repo} eq 'fathead'){
-            my $source = $ia->{src_id};
-            # by source number for fatheads
-            $ia_metadata{fathead_source}{$source} = $ia;
-            # by language for multi language wiki sources
-            # check that language is set since most fatheads don't have a language
-            if( my $lang = $ia->{src_options}{language}){
-                # By default use current source
-                my $want_src = $source;
-                if(exists $ia_metadata{fathead_lang}{$lang}){
-                    my $prev_ia = $ia_metadata{fathead_source}{$ia_metadata{fathead_lang}{$lang}};
-                    # Skip setting lang to source if existing src_id is lower
-                    $want_src = 0 if $prev_ia->{src_id} < $ia->{src_id};
-                }
-                $ia_metadata{fathead_lang}{$lang} = $want_src if $want_src;
-            }
-            my $min_length = $ia->{src_options}{min_abstract_length};
-            $ia_metadata{fathead_min_length}{$source} = $min_length if $min_length;
-        }
-    }
-
-    unless(%ia_metadata){
-        warn "[Error] No Instant Answer metadata loaded. Metadata will be downloaded\n",
-             "automatically and stored in $mdir if a network connection can be made\n",
-             "to https://duck.co.\n";
-    }
+	unless(%ia_metadata){
+		warn "[Error] No Instant Answer metadata loaded. Metadata will be downloaded\n",
+			"automatically and stored in $mdir if a network connection can be made\n",
+			"to https://duck.co.\n";
+	}
 }
 
 sub get_ia {
-    my ($self, $by, $lookup) = @_;
-    warn 'Get IA obj lookup params: ', p($lookup) if debug;
+	my ($self, $by, $lookup) = @_;
+	warn 'Get IA obj lookup params: ', p($lookup) if debug;
 
-    my $m = $ia_metadata{$by}{$lookup};
-    warn 'Returning IA ', p($m) if debug;
-    return $m;
+	my $m = $ia_metadata{$by}{$lookup};
+	warn 'Returning IA ', p($m) if debug;
+	return $m;
 }
 
 sub get_js {
-    my ($self, $by, $lookup) = @_;
-    return unless $by =~ /id|source/;
-    my $ia = $self->get_ia($by => $lookup);
-    return unless $ia;
+	my ($self, $by, $lookup) = @_;
+	return unless $by =~ /id|source/;
+	my $ia = $self->get_ia($by => $lookup);
+	return unless $ia;
 
-    my $id = $ia->{id};
-    my $metaj = eval { JSON::XS->new->ascii->encode($ia) } || return;
-    return qq(DDH.$id=DDH.$id||{};DDH.$id.meta=$metaj;); 
+	my $id = $ia->{id};
+	my $metaj = eval { JSON::XS->new->ascii->encode($ia) } || return;
+	return qq(DDH.$id=DDH.$id||{};DDH.$id.meta=$metaj;);
 }
 
 # return a hash of IA objects by id
@@ -150,14 +150,14 @@ sub fathead_by_length { $ia_metadata{fathead_min_length} }
 
 # Internal function.
 sub _js_callback_name {
-    my $name = shift;
-    my $fn;
-    if(($fn) = $name =~ /^DDG::\w+::(\w.+)$/o){
-        $fn =~ s/::/_/og;
-        $fn =~ s/([a-z])([A-Z])/$1_$2/og;
-        $fn = lc $fn;
-    }
-    return $fn;
+	my $name = shift;
+	my $fn;
+	if(($fn) = $name =~ /^DDG::\w+::(\w.+)$/o){
+		$fn =~ s/::/_/og;
+		$fn =~ s/([a-z])([A-Z])/$1_$2/og;
+		$fn = lc $fn;
+	}
+	return $fn;
 }
 
 1;


### PR DESCRIPTION
Currently there is no caching (AFAIK) for metadata - unless you turn off the downloading of new metadata entirely (`NO_METADATA_DOWNLOAD`) new metadata will always be downloaded.

I've replaced the original environment variable with a new variable, `DDG_METADATA_TIMEOUT`, that allows you to specify a time (in days) within which new metadata will not be downloaded.

In personal testing with commands like `duckpan server` I've had a very noticeable improvement in load times with the caching on.

Hopefully this will also help with things such as duckduckgo/p5-app-duckpan#321, although the caching for assets is separate and contained within DuckPAN itself.

***By default there is no caching***.

I think having this option available may be a large boost to those with slow internet connections (such as myself).

/cc @zachthompson @moollaza 