### PR TITLE
Fix broken links and placeholders in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,56 +15,8 @@ Before you can do anything, you first need a [GitHub account](https://github.com
     - Clearly describe the bug/improvemnt, including steps to reproduce when it is a bug
   - If one already exists, please add any additional comments you have regarding the matter
 
-If you're submitting a **pull request** (bugfix/addition):
-- Fork the **DuckDuckGo** repository on GitHub
-
-## Making Changes
-
-- Before making any changes, refer to the [DuckDuckHack Styleguide](https://github.com/duckduckgo/duckduckgo-documentation/blob/master/duckduckhack/resources/code_styleguide.md) to ensure your changes are made in the correct fashion
-- Make sure your commits are of a reasonable size. They shouldn't be too big (or too small)
-- Make sure your commit messages effectively explain what changes have been made, and please identify which instant answer or file has been modified:
-
-  ```shell
-  CONTRIBUTING.md - Add the example commit message because it was missing
-  ```
-
-  is much better than:
-
-  ```shell
-  Improve README
-  ```
-
-- Make sure you have added the necessary tests for your changes
-- Run `dzil test` (executes all tests in t/) to ensure nothing else was accidentally broken
-- If your change affects an instant answer, remember to add yourself to the Metadata attribution list in the appropriate `.pm` file
-
 ## Submitting Changes
 
-1. Commit your changes.
+- Find detailed instructions for adding an **Instant Answer** [here](http://docs.duckduckhack.com/submitting/pull-request.html)
+- For other changes, see [this handy guide](http://docs.duckduckhack.com/resources/git-workflow.html) on submitting a pull request
 
-  ```shell
-  git commit -a -m "My first instant answer that does X is ready to go!"
-  ```
-
-2. Get your commit history [how you like it](http://schacon.github.io/gitbook/4_interactive_rebasing.html).
-
-  ```shell
-  git rebase -i origin/master
-  ```
-
-  or
-
-  ```shell
-  git pull --rebase origin/master
-  ```
-
-3. Push your forked repository back to GitHub.
-
-  ```shell
-  git push
-  ```
-
-4. Add your info to the instant answer so we can give you credit for it on the [Goodies page](https://duckduckgo.com/goodies.html/). You'll see your name or handle on the live site!
-Check out the [Metadata README](https://github.com/duckduckgo/duckduckgo-documentation/blob/master/duckduckhack/submitting-your-instant-answer/metadata.md) for detailed instructions on how to include your name and links.
-
-5. Go into GitHub and submit a [pull request!](http://help.github.com/send-pull-requests/) to the **DuckDuckGo** repository, making sure to use the **DuckDuckGo** repository's **[Pull Request Template](https://github.com/duckduckgo/duckduckgo/blob/master/duckduckgo_pr_template.md)**. This will let us know about your changes and start the conversation about integrating it into the live code.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Before you can do anything, you first need a [GitHub account](https://github.com
 
 - Firstly, please make sure the bug is related to the **DuckDuckGo** repository. If this bug is about the DuckDuckGo API, or the relevancy of our search results, please visit our feedback page at <https://duckduckgo.com/feedback>. If you're unsure, its best to use the feedback page (your message will be passed along to the correct people).
 
-- Check the **DuckDuckGo** [issues](#link-to-issues) to see if an issue already exists for the given bug or suggestion
+- Check the **DuckDuckGo** [issues](https://github.com/duckduckgo/duckduckgo/issues) to see if an issue already exists for the given bug or suggestion
   - If one doesn't exist, create a GitHub issue in the **DuckDuckGo** repository
     - Clearly describe the bug/improvemnt, including steps to reproduce when it is a bug
   - If one already exists, please add any additional comments you have regarding the matter
@@ -20,18 +20,18 @@ If you're submitting a **pull request** (bugfix/addition):
 
 ## Making Changes
 
-- Before making any changes, refer to the [DuckDuckHack Styleguide](https://duck.co/duckduckhack/styleguide_overview) to ensure your changes are made in the correct fashion
+- Before making any changes, refer to the [DuckDuckHack Styleguide](https://github.com/duckduckgo/duckduckgo-documentation/blob/master/duckduckhack/resources/code_styleguide.md) to ensure your changes are made in the correct fashion
 - Make sure your commits are of a reasonable size. They shouldn't be too big (or too small)
 - Make sure your commit messages effectively explain what changes have been made, and please identify which instant answer or file has been modified:
 
   ```shell
-  CONTRIBUTING.md - Added the example commit message because it was missing
+  CONTRIBUTING.md - Add the example commit message because it was missing
   ```
 
   is much better than:
 
   ```shell
-  <bad_commit_example>
+  Improve README
   ```
 
 - Make sure you have added the necessary tests for your changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ If you're submitting a **pull request** (bugfix/addition):
   git push
   ```
 
-4. Add your info to the instant answer so we can give you credit for it on the [Goodies page](https://duckduckgo.com/goodies). You'll see your name or handle on the live site!
-Check out the [Metadata README](metadata.md) for detailed instructions on how to include your name and links.
+4. Add your info to the instant answer so we can give you credit for it on the [Goodies page](https://duckduckgo.com/goodies.html/). You'll see your name or handle on the live site!
+Check out the [Metadata README](https://github.com/duckduckgo/duckduckgo-documentation/blob/master/duckduckhack/submitting-your-instant-answer/metadata.md) for detailed instructions on how to include your name and links.
 
 5. Go into GitHub and submit a [pull request!](http://help.github.com/send-pull-requests/) to the **DuckDuckGo** repository, making sure to use the **DuckDuckGo** repository's **[Pull Request Template](https://github.com/duckduckgo/duckduckgo/blob/master/duckduckgo_pr_template.md)**. This will let us know about your changes and start the conversation about integrating it into the live code.


### PR DESCRIPTION
**Which issues (if any) does this change solve? (please link them here)**
  - The current contributing readme has placeholders for the URL to the issue list and the bad commit example. 
  - The links to the style guide and goodies page are non-working. 
  - The commit message examples use the past tense, unlike existing commits.

**Briefly describe your fix. Are there any important details we should know about?**
  - The link to the issues page now points to https://github.com/duckduckgo/duckduckgo/issues
  - The previously invalid link to the style guide now points to https://github.com/duckduckgo/duckduckgo-documentation/blob/master/duckduckhack/resources/code_styleguide.md
  - The previously invalid goodies link now points to https://duckduckgo.com/goodies.html/
  - The previously invalid metadata.md link now points to https://github.com/duckduckgo/duckduckgo-documentation/blob/master/duckduckhack/submitting-your-instant-answer/metadata.md
  - The bad commit example is now "Improve README"

**Are you having any problems? Do you need our help with anything?**
metadata.md was referred to when it doesn't exist, and I can't find any trace of it in this repository. Therefore I linked it to the version in the repository duckduckgo-documentation.