### PR TITLE
Goodie Tests: Remove '-ANY-' and regex tests

### DIFF
--- a/lib/DDG/Test/Goodie.pm
+++ b/lib/DDG/Test/Goodie.pm
@@ -90,9 +90,6 @@ testing your L<DDG::Goodie> alone or in combination with others.
 					if (ref $zci->$_ eq 'Regexp') {
 						like($answer->$_, $zci->$_, 'Regexp: ' . $_ );
 						$zci->{$_} = $answer->$_;
-					} elsif ($zci->$_ eq '-ANY-') {
-						pass('-ALL- pass: ' . $_);
-						$zci->{$_} = $answer->$_;
 					}
 				}
 				if ($zci->has_structured_answer) {
@@ -101,9 +98,6 @@ testing your L<DDG::Goodie> alone or in combination with others.
 					foreach my $key (grep { defined $e_sa->{$_} } sort keys %$e_sa) {
 						if (ref $e_sa->{$key} eq 'Regexp') {
 							like($g_sa->{$key}, $e_sa->{$key}, 'Regexp: structured_answer{' . $key . '}');
-							$g_sa->{$key} = $e_sa->{$key};
-						} elsif ($e_sa->{$key} eq '-ANY-') {
-							pass('-ALL- pass: structured_answer{' . $key . '}');
 							$g_sa->{$key} = $e_sa->{$key};
 						}
 					}

--- a/lib/DDG/Test/Goodie.pm
+++ b/lib/DDG/Test/Goodie.pm
@@ -85,23 +85,6 @@ testing your L<DDG::Goodie> alone or in combination with others.
 			my ($query, $answer, $zci) = @_;
 		subtest "Query: $query" => sub {
 			if ($answer) {
-				# Check regex tests
-				for (grep { defined $zci->$_ } qw/answer html heading/) {
-					if (ref $zci->$_ eq 'Regexp') {
-						like($answer->$_, $zci->$_, 'Regexp: ' . $_ );
-						$zci->{$_} = $answer->$_;
-					}
-				}
-				if ($zci->has_structured_answer) {
-					my $e_sa = $zci->structured_answer;
-					my $g_sa = $answer->structured_answer;
-					foreach my $key (grep { defined $e_sa->{$_} } sort keys %$e_sa) {
-						if (ref $e_sa->{$key} eq 'Regexp') {
-							like($g_sa->{$key}, $e_sa->{$key}, 'Regexp: structured_answer{' . $key . '}');
-							$g_sa->{$key} = $e_sa->{$key};
-						}
-					}
-				}
 				$zci->{caller} = $answer->caller;    # TODO: Review all this cheating; seriously.
 				cmp_deeply($answer,$zci,'Deep: full ZCI object');
 			} else {


### PR DESCRIPTION
@zachthompson We use `Test::Deep` now, so we don't need any of these workarounds.

Also, removing these means people will have to be more specific with things like, say, random tests; instead of just saying `data => '-ANY-'`, they will have to describe the data with (for example) regexes - leading to more comprehensive tests.

We'll need to update any tests that use these.

/cc @mintsoft @moollaza 