### PR TITLE
Meta::Data - support multi-metadata lookups

### DIFF
--- a/lib/DDG/Meta/Data.pm
+++ b/lib/DDG/Meta/Data.pm
@@ -132,9 +132,9 @@ sub _satisfy {
 	ref $lookup eq 'CODE' ? $lookup->($pby) : $pby eq $lookup;
 }
 
-# get_ias(repo => 'goodies', dev_milestone => 'live'...)
+# filter_ias(repo => 'goodies', dev_milestone => 'live'...)
 # Lookups combine as an AND operation.
-sub get_ias {
+sub filter_ias {
 	my (@lookups) = @_;
 	my @results = @ia_container;
 	foreach (pairs @lookups) {

--- a/lib/DDG/Meta/Data.pm
+++ b/lib/DDG/Meta/Data.pm
@@ -127,7 +127,6 @@ sub get_ia {
 
 sub _satisfy {
 	my ($ia, $by, $lookup) = @_;
-	return $by->($ia, $lookup) if ref $by eq 'CODE';
 	my $pby = $ia->{$by};
 	ref $lookup eq 'CODE' ? $lookup->($pby) : $pby eq $lookup;
 }

--- a/lib/DDG/Meta/Data.pm
+++ b/lib/DDG/Meta/Data.pm
@@ -125,6 +125,8 @@ sub get_ia {
 
 # filter_ias({ repo => 'goodies', dev_milestone => 'live'... })
 # Lookups combine as an AND operation.
+# Returns a list of IAs on `wantarray', otherwise an (id => ia) HASH ref.
+#
 # Each condition consists of a $key and $lookup.
 # $lookup should be either a string, ARRAY ref, or CODE ref.
 # If a string, then $lookup is compared with `eq'
@@ -149,7 +151,7 @@ sub filter_ias {
 			} @$lookup;
 		} (keys %lookups);
 	}
-	return \%ias;
+	return wantarray ? (values %ias) : \%ias;
 }
 
 sub get_js {

--- a/lib/DDG/Meta/Data.pm
+++ b/lib/DDG/Meta/Data.pm
@@ -6,7 +6,7 @@ use Path::Class;
 use File::ShareDir 'dist_file';
 use LWP::UserAgent;
 use File::Copy::Recursive 'pathmk';
-use List::Util qw( any );
+use List::Util qw( all any );
 
 use strict;
 
@@ -143,12 +143,10 @@ sub filter_ias {
 		$lookups{$_} = [$cond] unless ref $cond eq 'ARRAY';
 	} (keys %lookups);
 	while (my ($id, $ia) = each %ias) {
-		# This is weird, if we don't have some expression here involving %lookups
-		# then last won't run properly.
-		%lookups = %lookups;
-		while (my ($by, $lookup) = each %lookups) {
-			delete $ias{$id} and last unless any { _satisfy($ia, $by, $_) } @$lookup;
-		};
+		delete $ias{$id} unless all {
+			my ($by, $lookup) = ($_, $lookups{$_});
+			any { _satisfy($ia, $by, $_) } @$lookup;
+		} (keys %lookups);
 	}
 	return \%ias;
 }

--- a/lib/DDG/Meta/Data.pm
+++ b/lib/DDG/Meta/Data.pm
@@ -134,6 +134,13 @@ sub _satisfy {
 
 # filter_ias({ repo => 'goodies', dev_milestone => 'live'... })
 # Lookups combine as an AND operation.
+# Each condition consists of a $key and $lookup.
+# $lookup should be either a string, ARRAY ref, or CODE ref.
+# If a string, then $lookup is compared with `eq'
+# If a CODE ref, then $lookup is called with the IAs $key attribute and
+# should return a boolean value.
+# If an ARRAY ref, then the above two rules are used with each element, the
+# IA only needs to satisfy one.
 sub filter_ias {
 	my ($lookups) = @_;
 	my %ias = %{by_id()};

--- a/lib/DDG/Meta/Data.pm
+++ b/lib/DDG/Meta/Data.pm
@@ -135,7 +135,7 @@ sub get_ia {
 # If an ARRAY ref, then the above two rules are used with each element, the
 # IA only needs to satisfy one.
 sub filter_ias {
-	my ($lookups) = @_;
+	my $lookups = $_[1];
 	my %ias = %{by_id()};
 	my %lookups = %$lookups;
 	my @by = keys %lookups;

--- a/lib/DDG/Meta/Data.pm
+++ b/lib/DDG/Meta/Data.pm
@@ -6,7 +6,7 @@ use Path::Class;
 use File::ShareDir 'dist_file';
 use LWP::UserAgent;
 use File::Copy::Recursive 'pathmk';
-use List::Util qw( pairs );
+use List::Util qw( any pairs );
 
 use strict;
 
@@ -140,7 +140,11 @@ sub filter_ias {
 	foreach (pairs @$lookups) {
 		return () unless @results;
 		my ($by, $lookup) = @$_;
-		@results = grep { _satisfy($_, $by, $lookup) } @results;
+		my @lookup = ref $lookup eq 'ARRAY' ? @$lookup : ($lookup);
+		@results = grep {
+			my $ia = $_;
+			any { _satisfy($ia, $by, $_) } @lookup;
+		} @results;
 	}
 	return \@results;
 }

--- a/lib/DDG/Meta/Data.pm
+++ b/lib/DDG/Meta/Data.pm
@@ -136,6 +136,7 @@ sub filter_ias {
 	my ($lookups) = @_;
 	my %ias = %{by_id()};
 	my %lookups = %$lookups;
+	# Ensure lookups are of the form (by => [lookup...])
 	map {
 		my $cond = $lookups{$_};
 		$lookups{$_} = [$cond] unless ref $cond eq 'ARRAY';

--- a/lib/DDG/Meta/Data.pm
+++ b/lib/DDG/Meta/Data.pm
@@ -138,18 +138,19 @@ sub filter_ias {
 	my ($lookups) = @_;
 	my %ias = %{by_id()};
 	my %lookups = %$lookups;
+	my @by = keys %lookups;
 	# Ensure lookups are of the form (by => [lookup...])
 	map {
 		my $cond = $lookups{$_};
 		$lookups{$_} = [$cond] unless ref $cond eq 'ARRAY';
-	} (keys %lookups);
+	} @by;
 	while (my ($id, $ia) = each %ias) {
 		delete $ias{$id} unless all {
 			my ($by, $lookup) = ($_, $lookups{$_});
 			any {
 				ref $_ eq 'CODE' ? $_->($ia->{$by}) : $_ eq $ia->{$by};
 			} @$lookup;
-		} (keys %lookups);
+		} @by;
 	}
 	return wantarray ? (values %ias) : \%ias;
 }

--- a/lib/DDG/Meta/Data.pm
+++ b/lib/DDG/Meta/Data.pm
@@ -160,7 +160,7 @@ sub get_js {
 
     my $id = $ia->{id};
     my $metaj = eval { JSON::XS->new->ascii->encode($ia) } || return;
-    return qq(DDH.$id=DDH.$id||{};DDH.$id.meta=$metaj;); 
+    return qq(DDH.$id=DDH.$id||{};DDH.$id.meta=$metaj;);
 }
 
 # return a hash of IA objects by id

--- a/lib/DDG/Meta/Data.pm
+++ b/lib/DDG/Meta/Data.pm
@@ -125,12 +125,6 @@ sub get_ia {
     return $m;
 }
 
-sub _satisfy {
-	my ($ia, $by, $lookup) = @_;
-	my $pby = $ia->{$by};
-	ref $lookup eq 'CODE' ? $lookup->($pby) : $pby eq $lookup;
-}
-
 # filter_ias({ repo => 'goodies', dev_milestone => 'live'... })
 # Lookups combine as an AND operation.
 # Each condition consists of a $key and $lookup.
@@ -151,7 +145,9 @@ sub filter_ias {
 	while (my ($id, $ia) = each %ias) {
 		delete $ias{$id} unless all {
 			my ($by, $lookup) = ($_, $lookups{$_});
-			any { _satisfy($ia, $by, $_) } @$lookup;
+			any {
+				ref $_ eq 'CODE' ? $_->($ia->{$by}) : $_ eq $ia->{$by};
+			} @$lookup;
 		} (keys %lookups);
 	}
 	return \%ias;

--- a/lib/DDG/Meta/Data.pm
+++ b/lib/DDG/Meta/Data.pm
@@ -135,14 +135,14 @@ sub _satisfy {
 # filter_ias(repo => 'goodies', dev_milestone => 'live'...)
 # Lookups combine as an AND operation.
 sub filter_ias {
-	my (@lookups) = @_;
+	my ($lookups) = @_;
 	my @results = @ia_container;
-	foreach (pairs @lookups) {
+	foreach (pairs @$lookups) {
 		return () unless @results;
 		my ($by, $lookup) = @$_;
 		@results = grep { _satisfy($_, $by, $lookup) } @results;
 	}
-	return @results;
+	return \@results;
 }
 
 sub get_js {

--- a/lib/DDG/Meta/Data.pm
+++ b/lib/DDG/Meta/Data.pm
@@ -114,8 +114,6 @@ unless(%ia_metadata){
     }
 }
 
-my @ia_container = sort values by_id();
-
 sub get_ia {
     my ($self, $by, $lookup) = @_;
     warn 'Get IA obj lookup params: ', p($lookup) if debug;

--- a/lib/DDG/Meta/Data.pm
+++ b/lib/DDG/Meta/Data.pm
@@ -6,7 +6,7 @@ use Path::Class;
 use File::ShareDir 'dist_file';
 use LWP::UserAgent;
 use File::Copy::Recursive 'pathmk';
-use List::Util qw( any pairs );
+use List::Util qw( any );
 
 use strict;
 
@@ -132,14 +132,13 @@ sub _satisfy {
 	ref $lookup eq 'CODE' ? $lookup->($pby) : $pby eq $lookup;
 }
 
-# filter_ias(repo => 'goodies', dev_milestone => 'live'...)
+# filter_ias({ repo => 'goodies', dev_milestone => 'live'... })
 # Lookups combine as an AND operation.
 sub filter_ias {
 	my ($lookups) = @_;
 	my @results = @ia_container;
-	foreach (pairs @$lookups) {
+	while (my ($by, $lookup) = each %$lookups) {
 		return () unless @results;
-		my ($by, $lookup) = @$_;
 		my @lookup = ref $lookup eq 'ARRAY' ? @$lookup : ($lookup);
 		@results = grep {
 			my $ia = $_;


### PR DESCRIPTION
Add 'get_ias', which allows fetching of multiple IAs that satisfy some lookups joined in an AND condition.

For example, if you wanted to get all the cheat sheets that were live, you could do:

```perl
DDG::Meta::Data::get_ias(
    id => sub { $_[0] =~ /_cheat_sheet$/ }, 
    production_status => 'live'
);

# Gives a bunch of cheat sheets.
```

@zachthompson Got any improvements? It seems pretty good speed-wise, though I haven't profiled it...