### PR TITLE
Rudimentary POST support for Spice

### DIFF
--- a/lib/DDG/Meta/ZeroClickInfoSpice.pm
+++ b/lib/DDG/Meta/ZeroClickInfoSpice.pm
@@ -22,6 +22,7 @@ sub zeroclickinfospice_attributes {qw(
 	wrap_jsonp_callback
 	wrap_string_callback
 	accept_header
+	post_body
 	is_cached
 	is_unsafe
 	ttl
@@ -233,6 +234,7 @@ sub create_rewrite {
 		defined $params->{from} ? ( from => $params->{from}) : (),
 		defined $params->{proxy_cache_valid} ? ( proxy_cache_valid => $params->{proxy_cache_valid} ) : (),
 		defined $params->{proxy_ssl_session_reuse} ? ( proxy_ssl_session_reuse => $params->{proxy_ssl_session_reuse} ) : (),
+		defined $params->{post_body} ? ( post_body => $params->{post_body} ) : (),
 		callback => $callback,
 		path => $path,
 		wrap_jsonp_callback => $params->{wrap_jsonp_callback},

--- a/lib/DDG/Rewrite.pm
+++ b/lib/DDG/Rewrite.pm
@@ -108,6 +108,11 @@ has proxy_x_forwarded_for => (
         default => sub { 'X-Forwarded-For $proxy_add_x_forwarded_for' }
 );
 
+has post_body => (
+	is => 'ro',
+	predicate => 'has_post_body',
+);
+
 has nginx_conf => (
 	is => 'ro',
 	lazy => 1,
@@ -140,7 +145,11 @@ sub _build_nginx_conf {
 
 	my $cfg = "location ^~ ".$self->path." {\n";
 	$cfg .= "\tproxy_set_header Accept '".$self->accept_header."';\n" if $self->accept_header;
-	
+
+	if ( $self->has_post_body ) {
+		$cfg .= "\tproxy_method POST;\n";
+		$cfg .= "\tproxy_set_body '" . $self->post_body . "';\n";
+	}
 	if($uses_echo_module) {
 		# we need to make sure we have plain text coming back until we have a way
 		# to unilaterally gunzip responses from the upstream since the echo module

--- a/lib/DDG/Rewrite.pm
+++ b/lib/DDG/Rewrite.pm
@@ -142,6 +142,8 @@ sub _build_nginx_conf {
 	my $wrap_string_callback = $self->has_callback && $self->wrap_string_callback;
 	my $uses_echo_module = $wrap_jsonp_callback || $wrap_string_callback;
 	my $callback = $self->callback;
+	my ($spice_name) = $self->path =~ m{^/js/spice/(.+)/$};
+	$spice_name =~ s|/|_|og if $spice_name;
 
 	my $cfg = "location ^~ ".$self->path." {\n";
 	$cfg .= "\tproxy_set_header Accept '".$self->accept_header."';\n" if $self->accept_header;
@@ -173,8 +175,7 @@ sub _build_nginx_conf {
 	$cfg .= "\techo_before_body '$callback".qq|("';\n| if $wrap_string_callback;
 
 	my $upstream;
-	if(my ($spice_name) = $self->path =~ m{^/js/spice/(.+)/$}){
-		$spice_name =~ s|/|_|og;
+	if( $spice_name ) {
 		$upstream = '$'.$spice_name.'_upstream';
 		$cfg .= "\tset $upstream $scheme://$host:$port;\n";
 	} else {

--- a/lib/DDG/Rewrite.pm
+++ b/lib/DDG/Rewrite.pm
@@ -151,6 +151,14 @@ sub _build_nginx_conf {
 	if ( $self->has_post_body ) {
 		$cfg .= "\tproxy_method POST;\n";
 		$cfg .= "\tproxy_set_body '" . $self->post_body . "';\n";
+
+		# This block sets the proxy cache key from the spice name and the combined
+		# set of captured GET parameters. The 'map' builds a hash of these capture
+		# parameters as keys to ensure each one occurs only once. We can then pull these
+		# out consistently by calling 'sort keys' on the returned hash and 'join' turns
+		# the sorted keys into a single string.
+		# e.g. post_body '{"method":"$2","query":"$1","cleaned_query":"$1"}'
+		# Would give a $cache_keys value of '$1$2'
 		my $cache_keys = join '', sort keys {
 			map { $_ => 1 } ( $self->post_body =~ m/\$[0-9]+/g )
 		};

--- a/lib/DDG/Rewrite.pm
+++ b/lib/DDG/Rewrite.pm
@@ -151,6 +151,10 @@ sub _build_nginx_conf {
 	if ( $self->has_post_body ) {
 		$cfg .= "\tproxy_method POST;\n";
 		$cfg .= "\tproxy_set_body '" . $self->post_body . "';\n";
+		my $cache_keys = join '', sort keys {
+			map { $_ => 1 } ( $self->post_body =~ m/\$[0-9]+/g )
+		};
+		$cfg .= "\tproxy_cache_key spice_${spice_name}_$cache_keys;\n"
 	}
 	if($uses_echo_module) {
 		# we need to make sure we have plain text coming back until we have a way

--- a/t/55-rewrite.t
+++ b/t/55-rewrite.t
@@ -83,6 +83,7 @@ my $postrewrite = DDG::Rewrite->new(
 is($postrewrite->nginx_conf, 'location ^~ /js/spice/spice_name/ {
 	proxy_method POST;
 	proxy_set_body \'{"param2":"$2","param1":"$1"}\';
+	proxy_cache_key spice_spice_name_$1$2;
 	set $spice_name_upstream http://some.api:80;
 	rewrite ^/js/spice/spice_name/(.*) /$1 break;
 	proxy_pass $spice_name_upstream;

--- a/t/55-rewrite.t
+++ b/t/55-rewrite.t
@@ -74,6 +74,22 @@ is($dollarrewrite->nginx_conf,'location ^~ /js/spice/spice_name/ {
 }
 ','Checking {{dollar}} replacement');
 
+my $postrewrite = DDG::Rewrite->new(
+       path => '/js/spice/spice_name/',
+       to => 'http://some.api/$1',
+       post_body => '{"param2":"$2","param1":"$1"}',
+);
+
+is($postrewrite->nginx_conf, 'location ^~ /js/spice/spice_name/ {
+	proxy_method POST;
+	proxy_set_body \'{"param2":"$2","param1":"$1"}\';
+	set $spice_name_upstream http://some.api:80;
+	rewrite ^/js/spice/spice_name/(.*) /$1 break;
+	proxy_pass $spice_name_upstream;
+	expires 1s;
+}
+', 'Check POST body rewrite');
+
 my $minrewrite = DDG::Rewrite->new(
 	path => '/js/spice/spice_name/',
 	to => 'http://some.api/$1',


### PR DESCRIPTION
This change allows you to define a raw POST body in Spice with a new variable, `post_body`.

This will instruct nginx to `proxy_set_body` to your `post_body` (ideally filled in with captured GET vars) and change the request method to POST.

Cc: @russellholt @MariagraziaAlastra @moollaza @jdorweiler 