### PR TITLE
PM not required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
       DDG::SpiceBundle::OpenSourceDuckDuckGo
       DDG::FatheadBundle::OpenSourceDuckDuckGo
       DDG::LongtailBundle::OpenSourceDuckDuckGo
-  - dzil authordeps | grep -ve '^\W' | xargs -n 5 -P 10 cpanm --quiet --notest
+  - dzil authordeps | grep -ve '^\W' | xargs -n 5 -P 10 cpanm --mirror http://cpan.org --mirror http://duckpan.org --quiet --notest
   - dzil listdeps | grep -ve '^\W' | cpanm --quiet --notest --mirror http://www.cpan.org/ --mirror http://duckpan.org
 language: perl
 perl:

--- a/dist.ini
+++ b/dist.ini
@@ -10,6 +10,7 @@ module = Dist::Zilla::Plugin::UploadToDuckPAN
 
 [AutoPrereqs]
 skip = ^DDG::
+skip = Dist::Zilla::Plugin::UploadToDuckPAN
 
 [GatherDir]
 [PruneCruft]

--- a/dist.ini
+++ b/dist.ini
@@ -10,7 +10,6 @@ module = Dist::Zilla::Plugin::UploadToDuckPAN
 
 [AutoPrereqs]
 skip = ^DDG::
-skip = Dist::Zilla::Plugin::UploadToDuckPAN
 
 [GatherDir]
 [PruneCruft]


### PR DESCRIPTION
We don't require a Perl module any longer, e.g. fatheads/longtails, even dev for spices/goodies it's ok for it to be blank.

Definitely shouldn't be kicking out IAs without them.