### PR TITLE
Create files to allow install without Dist::Zilla

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -11,7 +11,13 @@ module = Dist::Zilla::Plugin::UploadToDuckPAN
 [AutoPrereqs]
 skip = ^DDG::
 
+[CPANFile]
+[CopyFilesFromBuild]
+copy = cpanfile
+copy = Makefile.PL
 [GatherDir]
+exclude_filename = cpanfile
+exclude_filename = Makefile.PL
 [PruneCruft]
 [ManifestSkip]
 [ExtraTests]


### PR DESCRIPTION
Dist::Zilla is great, but it has a ton of dependencies and is slow to install.
This change creates a Makefile.PL and a cpanfile so that the distribution
can be installed with perl Makefile.PL. The cpanfile allows dependencies to be
install by cpanm.

For background, see my article http://perltricks.com/article/203/2015/12/9/Create-GitHub-files-automatically-with-Dist--Zilla/
