### PR TITLE
Rewrite.pm: Fix "experimental keys on scalar" error

### DIFF
--- a/lib/DDG/Rewrite.pm
+++ b/lib/DDG/Rewrite.pm
@@ -149,7 +149,7 @@ sub _build_nginx_conf {
 
 	if ( $self->headers ) {
 		if ( ref $self->headers eq 'HASH' ) {
-			for my $header ( sort keys $self->headers ) {
+			for my $header ( sort keys %{$self->headers} ) {
 				$cfg .= "\tproxy_set_header $header \"" . $self->headers->{$header} . "\";\n";
 			}
 		}


### PR DESCRIPTION
I noticed several failures in the daily CPAN Testers Reports:

http://www.cpantesters.org/cpan/report/faf9be14-c233-11e6-b6b0-8c67e4596770

The issues is the same as what was addressed in #229, but it looks like one use of keys on a scalar was missed.

