### PR TITLE
NGiNX generated.conf: Add upstream timeout ability.

### DIFF
--- a/lib/DDG/Meta/ZeroClickInfoSpice.pm
+++ b/lib/DDG/Meta/ZeroClickInfoSpice.pm
@@ -28,6 +28,7 @@ sub zeroclickinfospice_attributes {qw(
 	ttl
 	error_fallback
 	alt_to
+        upstream_timeouts
 )}
 
 my %applied;
@@ -47,6 +48,7 @@ sub apply_keywords {
 		wrap_jsonp_callback => 0,
 		wrap_string_callback => 0,
 		accept_header => 0,
+                upstream_timeouts => +{},
 	);
 
 	my $stash = Package::Stash->new($target);
@@ -60,6 +62,7 @@ sub apply_keywords {
 		delete $params{'accept_header'};
 		delete $params{'proxy_cache_valid'};
 		delete $params{'proxy_ssl_session_reuse'};
+                delete $params{'upstream_timeouts'};
 		return DDG::ZeroClickInfo::Spice->new(
 			%params,
 		);
@@ -240,7 +243,8 @@ sub create_rewrite {
 		wrap_jsonp_callback => $params->{wrap_jsonp_callback},
 		wrap_string_callback => $params->{wrap_string_callback},
 		headers => $params->{headers},
-		error_fallback => $params->{error_fallback}
+		error_fallback => $params->{error_fallback},
+                upstream_timeouts => $params->{upstream_timeouts},
 	);
 }
 

--- a/t/55-rewrite.t
+++ b/t/55-rewrite.t
@@ -235,6 +235,6 @@ is($upstream_timeouts_rewrite->nginx_conf,'location ^~ /js/spice/spice_name/ {
 	proxy_ssl_server_name on;
 	expires 1s;
 }
-','Checking generated nginx.conf');
+','Checking generated nginx.conf for upstream timeouts.');
 
 done_testing;


### PR DESCRIPTION
Reviewer: @marcantonio 
CC: @kablamo @malbin @bsstoner @zachthompson 

Description: This PR adds the ability for a spice to control the NGiNX proxy_{connect,send,read}_timeout variables.

This is in direct response to the issues we've been having with Wordnik. I'm not 100% sure that this will hit the error_page directive (I will be testing that). That will then call the `DDG.spice.failed('some_spice');` when we exceed any of these timeouts. I think it may just work that way now.