### PR TITLE
ShareDir: Replace Path::Class `subdir` with Path::Tiny `child` method (when available)

### DIFF
--- a/lib/DDG/Meta/ShareDir.pm
+++ b/lib/DDG/Meta/ShareDir.pm
@@ -100,6 +100,10 @@ B<share/spice/test_test>.
 
 }
 
+# Temporarily add support for both `subdir` and `child` methods
+# to ensure backwards compatibilty while we upgrade Module::Data
+# throughout our stack
+# More info: https://github.com/duckduckgo/duckduckgo/pull/244 
 sub get_lib {
 	my $basedir = shift;
 	return -e $basedir->subdir('lib') if $basedir->can('subdir');

--- a/lib/DDG/Meta/ShareDir.pm
+++ b/lib/DDG/Meta/ShareDir.pm
@@ -48,7 +48,7 @@ sub apply_keywords {
 
 	my $share;
 
-	if ( -e $basedir->subdir('lib') and -e $basedir->subdir('share') ) {
+	if ( -e $basedir->child('lib') and -e $basedir->child('share') ) {
 		my $dir = dir($basedir,$share_path);
 		$share = $dir if -d $dir;
 	} else {
@@ -75,7 +75,7 @@ installation of the module.
 
 		$stash->add_symbol('&share', sub {
 			@_ ? -d dir($share,@_)
-				? $share->subdir(@_)
+				? $share->sudir(@_)
 				: $share->file(@_)
 			: $share
 		});

--- a/lib/DDG/Meta/ShareDir.pm
+++ b/lib/DDG/Meta/ShareDir.pm
@@ -75,7 +75,7 @@ installation of the module.
 
 		$stash->add_symbol('&share', sub {
 			@_ ? -d dir($share,@_)
-				? $share->sudir(@_)
+				? $share->subdir(@_)
 				: $share->file(@_)
 			: $share
 		});

--- a/lib/DDG/Meta/ShareDir.pm
+++ b/lib/DDG/Meta/ShareDir.pm
@@ -48,7 +48,7 @@ sub apply_keywords {
 
 	my $share;
 
-	if ( -e $basedir->child('lib') and -e $basedir->child('share') ) {
+	if ( get_lib($basedir) and get_share($basedir) ) {
 		my $dir = dir($basedir,$share_path);
 		$share = $dir if -d $dir;
 	} else {
@@ -100,4 +100,15 @@ B<share/spice/test_test>.
 
 }
 
+sub get_lib {
+	my $basedir = shift;
+	return -e $basedir->subdir('lib') if $basedir->can('subdir');
+	return -e $basedir->child('lib');
+}
+
+sub get_share {
+	my $basedir = shift;
+	return -e $basedir->subdir('share') if $basedir->can('subdir');
+	return -e $basedir->child('share');
+}
 1;


### PR DESCRIPTION
Assignee: @zachthompson 
/cc: @mintsoft 

## Background
Our `Module::Data` dependency recently switched from using `Path::Class` to `Path::Tiny`. As a result, `$basedir` is now a `Path::Tiny` object, so the `Path::Class`, `subdir` method we call no longer works.

Temporarily we are going to support both `subdir` and `child` to prevent any breakage while upgrading `Module::Data` throughout our code.

Later we will deprecate use of `subdir`.

This manifested in [failing Travis tests](https://travis-ci.org/duckduckgo/zeroclickinfo-goodies/builds/218573065#L6) in the Goodie repo. I recently cleared all the caches (trying to fix something else) and so the modules were forced to update.

## Reproduce Failure
1. `cpanm Module::Data`
2. `cd zeroclickinfo-goodies && duckpan test`
3. All tests should fail

## Testing Fix
1. Install new DDG Bundle
2. `cd zeroclickinfo-goodies && duckpan test`
3. All tests should now pass again

### Note:
This change will require us to upgrade `Module::Data` in our production stack before this can be released. 