### PR TITLE
Module::Data uses Path::Tiny instead of Path::Class

### DIFF
--- a/lib/DDG/Meta/ShareDir.pm
+++ b/lib/DDG/Meta/ShareDir.pm
@@ -48,7 +48,7 @@ sub apply_keywords {
 
 	my $share;
 
-	if ( -e $basedir->subdir('lib') and -e $basedir->subdir('share') ) {
+	if ( -e $basedir->child('lib') and -e $basedir->child('share') ) {
 		my $dir = dir($basedir,$share_path);
 		$share = $dir if -d $dir;
 	} else {


### PR DESCRIPTION
Hi All,

 I was getting the following error on my stagging server while running  "duckpan server".

```
Can't locate object method "subdir" via package "Path::Tiny" at /usr/local/share/perl/5.18.2/DDG/Meta/ShareDir.pm line 3
```

This PR would replace the 'subdir' function  with 'child' as Module::Data uses Path::Tiny instead of Path::Class